### PR TITLE
Feature/add surrogate key for unique queue

### DIFF
--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/DeletionJob.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/DeletionJob.java
@@ -1,0 +1,7 @@
+package io.paradoxical.cassieq.dataAccess;
+
+import lombok.Data;
+
+@Data
+public class DeletionJob {
+}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/DeletionJob.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/DeletionJob.java
@@ -1,7 +1,9 @@
 package io.paradoxical.cassieq.dataAccess;
 
 import io.paradoxical.cassieq.model.BucketSize;
+import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueName;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
@@ -11,4 +13,12 @@ public class DeletionJob {
     private final int version;
 
     private final BucketSize bucketSize;
+
+    public DeletionJob(QueueDefinition definition){
+        this.queueName = definition.getQueueName();
+
+        this.version = definition.getVersion();
+
+        this.bucketSize = definition.getBucketSize();
+    }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/DeletionJob.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/DeletionJob.java
@@ -1,7 +1,14 @@
 package io.paradoxical.cassieq.dataAccess;
 
+import io.paradoxical.cassieq.model.BucketSize;
+import io.paradoxical.cassieq.model.QueueName;
 import lombok.Data;
 
 @Data
 public class DeletionJob {
+    private final QueueName queueName;
+
+    private final int version;
+
+    private final BucketSize bucketSize;
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageDeletorJobProcessorImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageDeletorJobProcessorImpl.java
@@ -1,0 +1,132 @@
+package io.paradoxical.cassieq.dataAccess;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeletorJobProcessor;
+import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
+import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
+import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
+import io.paradoxical.cassieq.factories.MonotonicRepoFactory;
+import io.paradoxical.cassieq.factories.PointerRepoFactory;
+import io.paradoxical.cassieq.model.BucketSize;
+import io.paradoxical.cassieq.model.InvisibilityMessagePointer;
+import io.paradoxical.cassieq.model.MessagePointer;
+import io.paradoxical.cassieq.model.MonotonicIndex;
+import io.paradoxical.cassieq.model.QueueId;
+import io.paradoxical.cassieq.model.QueueStatus;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.in;
+
+public class MessageDeletorJobProcessorImpl implements MessageDeletorJobProcessor {
+    private final Session session;
+    private final QueueRepository queueRepository;
+    private final DeletionJob job;
+    private final PointerRepository pointerRepository;
+    private final MonotonicRepository monotonicRepository;
+
+    @Inject
+    public MessageDeletorJobProcessorImpl(
+            Session session,
+            PointerRepoFactory pointerRepoFactory,
+            MonotonicRepoFactory monotonicRepoFactory,
+            QueueRepository queueRepository,
+            @Assisted DeletionJob job) {
+        this.session = session;
+        this.queueRepository = queueRepository;
+        this.job = job;
+
+        QueueId queueId = QueueId.valueOf(job.getQueueName(), job.getVersion());
+
+        pointerRepository = pointerRepoFactory.forQueue(queueId);
+        monotonicRepository = monotonicRepoFactory.forQueue(queueId);
+    }
+
+    /**
+     * Handles deleting messages and marking the job as complete
+     */
+    @Override
+    public void start() {
+        final MessagePointer startPointer = getMinStartPointer(pointerRepository, job.getBucketSize());
+
+        final MessagePointer endPointer = monotonicRepository.getCurrent();
+
+        delete(startPointer, endPointer);
+
+        monotonicRepository.deleteAll();
+
+        pointerRepository.deleteAll();
+
+        complete();
+    }
+
+    private void complete() {
+        // queue definition is now totally inactive
+        queueRepository.tryAdvanceQueueStatus(job.getQueueName(), QueueStatus.Inactive);
+
+        queueRepository.deleteCompletionJob(job);
+    }
+
+
+    private MessagePointer getMinStartPointer(PointerRepository pointerRepository, BucketSize bucketSize) {
+        final MonotonicIndex repairPointer = pointerRepository.getRepairCurrentBucketPointer().startOf(bucketSize);
+
+        final InvisibilityMessagePointer currentInvisPointer = pointerRepository.getCurrentInvisPointer();
+
+        if (repairPointer.get() < currentInvisPointer.get()) {
+            return repairPointer;
+        }
+
+        return currentInvisPointer;
+    }
+
+    private void delete(MessagePointer from, MessagePointer to) {
+
+        final int lastBucketNumber = to.toBucketPointer(job.getBucketSize()).get().intValue();
+        final int firstBucketNumber = from.toBucketPointer(job.getBucketSize()).get().intValue();
+
+        List<Integer> batchBucketsToDelete = new ArrayList<>();
+
+        final Iterator<Integer> bucketRangeIterator = IntStream.range(firstBucketNumber, lastBucketNumber + 1)
+                                                               .boxed()
+                                                               .iterator();
+
+        while (bucketRangeIterator.hasNext()) {
+            batchBucketsToDelete.add(bucketRangeIterator.next());
+
+            if (batchBucketsToDelete.size() == getDeleteBatchSize()) {
+                deleteAllMessagesInBuckets(ImmutableList.copyOf(batchBucketsToDelete));
+
+                batchBucketsToDelete.clear();
+            }
+        }
+
+        if (!CollectionUtils.isEmpty(batchBucketsToDelete)) {
+            deleteAllMessagesInBuckets(ImmutableList.copyOf(batchBucketsToDelete));
+        }
+    }
+
+    private int getDeleteBatchSize() {
+        return 100;
+    }
+
+    private void deleteAllMessagesInBuckets(final List<Integer> deletableBuckets) {
+        final Statement delete = QueryBuilder.delete()
+                                             .all()
+                                             .from(Tables.Message.TABLE_NAME)
+                                             .where(eq(Tables.Message.QUEUE_ID, QueueId.valueOf(job.getQueueName(), job.getVersion()).get()))
+                                             .and(in(Tables.Message.BUCKET_NUM, deletableBuckets));
+
+        session.execute(delete);
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageRepositoryImpl.java
@@ -57,7 +57,7 @@ public class MessageRepositoryImpl extends RepositoryBase implements MessageRepo
 
         Statement statement = QueryBuilder.insertInto(Tables.Message.TABLE_NAME)
                                           .ifNotExists()
-                                          .value(Tables.Message.QUEUENAME, queueDefinition.getQueueName().get())
+                                          .value(Tables.Message.QUEUE_ID, queueDefinition.getId().get())
                                           .value(Tables.Message.BUCKET_NUM, bucketPointer)
                                           .value(Tables.Message.MONOTON, message.getIndex().get())
                                           .value(Tables.Message.VERSION, 1)
@@ -90,7 +90,7 @@ public class MessageRepositoryImpl extends RepositoryBase implements MessageRepo
                                                 .with(set(Tables.Message.NEXT_VISIBLE_ON, newInvisTime.toDate()))
                                                 .and(set(Tables.Message.VERSION, newVersion))
                                                 .and(set(Tables.Message.DELIVERY_COUNT, deliveryCount))
-                                                .where(eq(Tables.Message.QUEUENAME, queueDefinition.getQueueName().get()))
+                                                .where(eq(Tables.Message.QUEUE_ID, queueDefinition.getId().get()))
                                                 .and(eq(Tables.Message.BUCKET_NUM, bucketPointer))
                                                 .and(eq(Tables.Message.MONOTON, message.getIndex().get()))
                                                 .onlyIf(eq(Tables.Message.VERSION, message.getVersion()))
@@ -117,7 +117,7 @@ public class MessageRepositoryImpl extends RepositoryBase implements MessageRepo
         Statement statement = QueryBuilder.update(Tables.Message.TABLE_NAME)
                                           .with(set(Tables.Message.ACKED, true))
                                           .and(set(Tables.Message.VERSION, message.getVersion() + 1))
-                                          .where(eq(Tables.Message.QUEUENAME, queueDefinition.getQueueName().get()))
+                                          .where(eq(Tables.Message.QUEUE_ID, queueDefinition.getId().get()))
                                           .and(eq(Tables.Message.BUCKET_NUM, bucketPointer))
                                           .and(eq(Tables.Message.MONOTON, message.getIndex().get()))
                                           .onlyIf(eq(Tables.Message.VERSION, message.getVersion()));
@@ -134,7 +134,7 @@ public class MessageRepositoryImpl extends RepositoryBase implements MessageRepo
         final DateTime now = getNow();
         Statement statement = QueryBuilder.insertInto(Tables.Message.TABLE_NAME)
                                           .ifNotExists()
-                                          .value(Tables.Message.QUEUENAME, queueDefinition.getQueueName().get())
+                                          .value(Tables.Message.QUEUE_ID, queueDefinition.getId().get())
                                           .value(Tables.Message.BUCKET_NUM, bucketPointer.get())
                                           .value(Tables.Message.ACKED, true)
                                           .value(Tables.Message.MONOTON, Tombstone.index.get())
@@ -148,7 +148,7 @@ public class MessageRepositoryImpl extends RepositoryBase implements MessageRepo
         return QueryBuilder.select()
                            .all()
                            .from(Tables.Message.TABLE_NAME)
-                           .where(eq(Tables.Message.QUEUENAME, queueDefinition.getQueueName().get()))
+                           .where(eq(Tables.Message.QUEUE_ID, queueDefinition.getId().get()))
                            .and(eq(Tables.Message.BUCKET_NUM, bucketPointer.get()));
     }
 
@@ -176,7 +176,7 @@ public class MessageRepositoryImpl extends RepositoryBase implements MessageRepo
         final Statement delete = QueryBuilder.delete()
                                              .all()
                                              .from(Tables.Message.TABLE_NAME)
-                                             .where(eq(Tables.Message.QUEUENAME, queueDefinition.getQueueName().get()))
+                                             .where(eq(Tables.Message.QUEUE_ID, queueDefinition.getId().get()))
                                              .and(eq(Tables.Message.BUCKET_NUM, bucket.get()));
 
         session.execute(delete);
@@ -217,7 +217,7 @@ public class MessageRepositoryImpl extends RepositoryBase implements MessageRepo
         final Statement delete = QueryBuilder.delete()
                                              .all()
                                              .from(Tables.Message.TABLE_NAME)
-                                             .where(eq(Tables.Message.QUEUENAME, queueDefinition.getQueueName().get()))
+                                             .where(eq(Tables.Message.QUEUE_ID, queueDefinition.getId().get()))
                                              .and(in(Tables.Message.BUCKET_NUM, deletableBuckets));
 
         session.execute(delete);

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.assistedinject.Assisted;
@@ -198,14 +199,14 @@ public class MessageRepositoryImpl extends RepositoryBase implements MessageRepo
             batchBucketsToDelete.add(bucketRangeIterator.next());
 
             if (batchBucketsToDelete.size() == getDeleteBatchSize()) {
-                deleteAllMessagesInBuckets(batchBucketsToDelete);
+                deleteAllMessagesInBuckets(ImmutableList.copyOf(batchBucketsToDelete));
 
                 batchBucketsToDelete.clear();
             }
         }
 
         if (!CollectionUtils.isEmpty(batchBucketsToDelete)) {
-            deleteAllMessagesInBuckets(batchBucketsToDelete);
+            deleteAllMessagesInBuckets(ImmutableList.copyOf(batchBucketsToDelete));
         }
     }
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MonotonicRepoImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MonotonicRepoImpl.java
@@ -39,7 +39,7 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
         Statement statement = QueryBuilder.select()
                                           .all()
                                           .from(Tables.Monoton.TABLE_NAME)
-                                          .where(eq(Tables.Monoton.QUEUE_NAME, queueId.get()));
+                                          .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()));
 
         MonotonicIndex current = getOne(session.execute(statement), MonotonicIndex::map);
 
@@ -50,7 +50,7 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
     public void deleteAll() {
         final Statement delete = QueryBuilder.delete().all()
                                              .from(Tables.Monoton.TABLE_NAME)
-                                             .where(eq(Tables.Monoton.QUEUE_NAME, queueId.get()));
+                                             .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()));
 
         session.execute(delete);
     }
@@ -62,7 +62,7 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
 
         Statement stat = QueryBuilder.update(Tables.Monoton.TABLE_NAME)
                                      .with(set(Tables.Monoton.VALUE, next))
-                                     .where(eq(Tables.Monoton.QUEUE_NAME, queueId.get()))
+                                     .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()))
                                      .onlyIf(eq(Tables.Monoton.VALUE, current));
 
         if (session.execute(stat).wasApplied()) {

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MonotonicRepoImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MonotonicRepoImpl.java
@@ -39,7 +39,7 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
         Statement statement = QueryBuilder.select()
                                           .all()
                                           .from(Tables.Monoton.TABLE_NAME)
-                                          .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()));
+                                          .where(eq(Tables.Monoton.QUEUE_NAME, queueId.get()));
 
         MonotonicIndex current = getOne(session.execute(statement), MonotonicIndex::map);
 
@@ -50,7 +50,7 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
     public void deleteAll() {
         final Statement delete = QueryBuilder.delete().all()
                                              .from(Tables.Monoton.TABLE_NAME)
-                                             .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()));
+                                             .where(eq(Tables.Monoton.QUEUE_NAME, queueId.get()));
 
         session.execute(delete);
     }
@@ -62,7 +62,7 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
 
         Statement stat = QueryBuilder.update(Tables.Monoton.TABLE_NAME)
                                      .with(set(Tables.Monoton.VALUE, next))
-                                     .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()))
+                                     .where(eq(Tables.Monoton.QUEUE_NAME, queueId.get()))
                                      .onlyIf(eq(Tables.Monoton.VALUE, current));
 
         if (session.execute(stat).wasApplied()) {

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MonotonicRepoImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MonotonicRepoImpl.java
@@ -3,40 +3,43 @@ package io.paradoxical.cassieq.dataAccess;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
-import io.paradoxical.cassieq.model.MonotonicIndex;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
-import io.paradoxical.cassieq.model.QueueName;
+import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
+import io.paradoxical.cassieq.model.MonotonicIndex;
+import io.paradoxical.cassieq.model.QueueDefinition;
+import io.paradoxical.cassieq.model.QueueId;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 
 public class MonotonicRepoImpl extends RepositoryBase implements MonotonicRepository {
     private final Session session;
-    private final QueueName queueName;
+    private final QueueId queueId;
 
     @Inject
-    public MonotonicRepoImpl(Session session, @Assisted QueueName queueName) {
+    public MonotonicRepoImpl(Session session, @Assisted QueueDefinition definition) {
         this.session = session;
-        this.queueName = queueName;
+        this.queueId = definition.getId();
     }
 
-    @Override public MonotonicIndex nextMonotonic() {
+    @Override
+    public MonotonicIndex nextMonotonic() {
         MonotonicIndex nextMonotonic = null;
 
-        while(nextMonotonic == null) {
+        while (nextMonotonic == null) {
             nextMonotonic = incrementMonotonicValue();
         }
 
         return nextMonotonic;
     }
 
-    @Override public MonotonicIndex getCurrent() {
+    @Override
+    public MonotonicIndex getCurrent() {
         Statement statement = QueryBuilder.select()
                                           .all()
                                           .from(Tables.Monoton.TABLE_NAME)
-                                          .where(eq(Tables.Monoton.QUEUENAME, queueName.get()));
+                                          .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()));
 
         MonotonicIndex current = getOne(session.execute(statement), MonotonicIndex::map);
 
@@ -47,7 +50,7 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
     public void deleteAll() {
         final Statement delete = QueryBuilder.delete().all()
                                              .from(Tables.Monoton.TABLE_NAME)
-                                             .where(eq(Tables.Monoton.QUEUENAME, queueName.get()));
+                                             .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()));
 
         session.execute(delete);
     }
@@ -59,10 +62,10 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
 
         Statement stat = QueryBuilder.update(Tables.Monoton.TABLE_NAME)
                                      .with(set(Tables.Monoton.VALUE, next))
-                                     .where(eq(Tables.Monoton.QUEUENAME, queueName.get()))
+                                     .where(eq(Tables.Monoton.QUEUE_ID, queueId.get()))
                                      .onlyIf(eq(Tables.Monoton.VALUE, current));
 
-        if(session.execute(stat).wasApplied()) {
+        if (session.execute(stat).wasApplied()) {
             return MonotonicIndex.valueOf(current);
         }
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MonotonicRepoImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MonotonicRepoImpl.java
@@ -7,7 +7,6 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
 import io.paradoxical.cassieq.model.MonotonicIndex;
-import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueId;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
@@ -18,9 +17,9 @@ public class MonotonicRepoImpl extends RepositoryBase implements MonotonicReposi
     private final QueueId queueId;
 
     @Inject
-    public MonotonicRepoImpl(Session session, @Assisted QueueDefinition definition) {
+    public MonotonicRepoImpl(Session session, @Assisted QueueId id) {
         this.session = session;
-        this.queueId = definition.getId();
+        this.queueId = id;
     }
 
     @Override

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
@@ -12,7 +12,8 @@ import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
 import io.paradoxical.cassieq.model.InvisibilityMessagePointer;
 import io.paradoxical.cassieq.model.Pointer;
 import io.paradoxical.cassieq.model.PointerType;
-import io.paradoxical.cassieq.model.QueueName;
+import io.paradoxical.cassieq.model.QueueDefinition;
+import io.paradoxical.cassieq.model.QueueId;
 import io.paradoxical.cassieq.model.ReaderBucketPointer;
 import io.paradoxical.cassieq.model.RepairBucketPointer;
 import lombok.NonNull;
@@ -25,14 +26,14 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 
 public class PointerRepositoryImpl extends RepositoryBase implements PointerRepository {
     private final Session session;
-    private final QueueName queueName;
+    private final QueueId queueId;
 
     @Inject
     public PointerRepositoryImpl(
             @NonNull Provider<Session> session,
-            @NonNull @Assisted QueueName queueName) {
+            @NonNull @Assisted QueueDefinition definition) {
         this.session = session.get();
-        this.queueName = queueName;
+        this.queueId = definition.getId();
     }
 
     @Override
@@ -101,7 +102,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
     public void deleteAll() {
         final Statement delete = QueryBuilder.delete().all()
                                              .from(Tables.Pointer.TABLE_NAME)
-                                             .where(eq(Tables.Pointer.QUEUENAME, queueName.get()));
+                                             .where(eq(Tables.Pointer.QUEUE_ID, queueId.get()));
 
         session.execute(delete);
     }
@@ -110,7 +111,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
         Statement query = QueryBuilder.select()
                                       .all()
                                       .from(Tables.Pointer.TABLE_NAME)
-                                      .where(eq(Tables.Pointer.QUEUENAME, queueName.get()))
+                                      .where(eq(Tables.Pointer.QUEUE_ID, queueId.get()))
                                       .and(eq(Tables.Pointer.POINTER_TYPE, pointerType.toString()));
 
         return getOne(session.execute(query), mapper);
@@ -120,7 +121,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
 
         Statement statement = QueryBuilder.update(Tables.Pointer.TABLE_NAME)
                                           .with(set(Tables.Pointer.VALUE, destination.get()))
-                                          .where(eq(Tables.Pointer.QUEUENAME, queueName.get()))
+                                          .where(eq(Tables.Pointer.QUEUE_ID, queueId.get()))
                                           .and(eq(Tables.Pointer.POINTER_TYPE, pointerType.toString()))
                                           .onlyIf(clause);
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
@@ -102,7 +102,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
     public void deleteAll() {
         final Statement delete = QueryBuilder.delete().all()
                                              .from(Tables.Pointer.TABLE_NAME)
-                                             .where(eq(Tables.Pointer.QUEUE_ID, queueId.get()));
+                                             .where(eq(Tables.Pointer.QUEUE_NAME, g.get()));
 
         session.execute(delete);
     }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
@@ -12,8 +12,7 @@ import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
 import io.paradoxical.cassieq.model.InvisibilityMessagePointer;
 import io.paradoxical.cassieq.model.Pointer;
 import io.paradoxical.cassieq.model.PointerType;
-import io.paradoxical.cassieq.model.QueueDefinition;
-import io.paradoxical.cassieq.model.QueueName;
+import io.paradoxical.cassieq.model.QueueId;
 import io.paradoxical.cassieq.model.ReaderBucketPointer;
 import io.paradoxical.cassieq.model.RepairBucketPointer;
 import lombok.NonNull;
@@ -26,16 +25,14 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 
 public class PointerRepositoryImpl extends RepositoryBase implements PointerRepository {
     private final Session session;
-    private final QueueName queueName;
-    private final QueueDefinition definition;
+    private final QueueId id;
 
     @Inject
     public PointerRepositoryImpl(
             @NonNull Provider<Session> session,
-            @NonNull @Assisted QueueDefinition definition) {
-        this.definition = definition;
+            @NonNull @Assisted QueueId id) {
+        this.id = id;
         this.session = session.get();
-        this.queueName = definition.getQueueName();
     }
 
     @Override
@@ -104,7 +101,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
     public void deleteAll() {
         final Statement delete = QueryBuilder.delete().all()
                                              .from(Tables.Pointer.TABLE_NAME)
-                                             .where(eq(Tables.Pointer.QUEUE_ID, definition.getId().get()));
+                                             .where(eq(Tables.Pointer.QUEUE_ID, id.get()));
 
         session.execute(delete);
     }
@@ -113,7 +110,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
         Statement query = QueryBuilder.select()
                                       .all()
                                       .from(Tables.Pointer.TABLE_NAME)
-                                      .where(eq(Tables.Pointer.QUEUE_ID, definition.getId().get()))
+                                      .where(eq(Tables.Pointer.QUEUE_ID, id.get()))
                                       .and(eq(Tables.Pointer.POINTER_TYPE, pointerType.toString()));
 
         return getOne(session.execute(query), mapper);
@@ -123,7 +120,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
 
         Statement statement = QueryBuilder.update(Tables.Pointer.TABLE_NAME)
                                           .with(set(Tables.Pointer.VALUE, destination.get()))
-                                          .where(eq(Tables.Pointer.QUEUE_ID, definition.getId().get()))
+                                          .where(eq(Tables.Pointer.QUEUE_ID, id.get()))
                                           .and(eq(Tables.Pointer.POINTER_TYPE, pointerType.toString()))
                                           .onlyIf(clause);
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
@@ -14,6 +14,7 @@ import io.paradoxical.cassieq.model.Pointer;
 import io.paradoxical.cassieq.model.PointerType;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueId;
+import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.ReaderBucketPointer;
 import io.paradoxical.cassieq.model.RepairBucketPointer;
 import lombok.NonNull;
@@ -26,14 +27,14 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 
 public class PointerRepositoryImpl extends RepositoryBase implements PointerRepository {
     private final Session session;
-    private final QueueId queueId;
+    private final QueueName queueName;
 
     @Inject
     public PointerRepositoryImpl(
             @NonNull Provider<Session> session,
             @NonNull @Assisted QueueDefinition definition) {
         this.session = session.get();
-        this.queueId = definition.getId();
+        this.queueName = definition.getQueueName();
     }
 
     @Override
@@ -102,7 +103,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
     public void deleteAll() {
         final Statement delete = QueryBuilder.delete().all()
                                              .from(Tables.Pointer.TABLE_NAME)
-                                             .where(eq(Tables.Pointer.QUEUE_NAME, g.get()));
+                                             .where(eq(Tables.Pointer.QUEUE_NAME, queueName.get()));
 
         session.execute(delete);
     }
@@ -111,7 +112,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
         Statement query = QueryBuilder.select()
                                       .all()
                                       .from(Tables.Pointer.TABLE_NAME)
-                                      .where(eq(Tables.Pointer.QUEUE_ID, queueId.get()))
+                                      .where(eq(Tables.Pointer.QUEUE_NAME, queueName.get()))
                                       .and(eq(Tables.Pointer.POINTER_TYPE, pointerType.toString()));
 
         return getOne(session.execute(query), mapper);
@@ -121,7 +122,7 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
 
         Statement statement = QueryBuilder.update(Tables.Pointer.TABLE_NAME)
                                           .with(set(Tables.Pointer.VALUE, destination.get()))
-                                          .where(eq(Tables.Pointer.QUEUE_ID, queueId.get()))
+                                          .where(eq(Tables.Pointer.QUEUE_NAME, queueName.get()))
                                           .and(eq(Tables.Pointer.POINTER_TYPE, pointerType.toString()))
                                           .onlyIf(clause);
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/QueueRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/QueueRepositoryImpl.java
@@ -1,6 +1,5 @@
 package io.paradoxical.cassieq.dataAccess;
 
-import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.Insert;
@@ -9,11 +8,9 @@ import com.datastax.driver.core.querybuilder.Select;
 import com.datastax.driver.core.querybuilder.Update;
 import com.godaddy.logging.Logger;
 import com.google.inject.Inject;
-import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.model.PointerType;
 import io.paradoxical.cassieq.model.QueueDefinition;
-import io.paradoxical.cassieq.model.QueueId;
 import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.QueueStatus;
 import lombok.NonNull;
@@ -42,175 +39,146 @@ public class QueueRepositoryImpl extends RepositoryBase implements QueueReposito
 
     @Override
     public void markForDeletion(final QueueDefinition definition) {
-        if(trySetQueueDefinitionStatus(definition.getId(), QueueStatus.Deleting)) {
-            if (trySetQueueNameAvailableStatus(definition, QueueStatus.Inactive)) {
-                logger.with("definition", definition).success("Marked for deletion");
-            }
+        if (trySetQueueDefinitionStatus(definition.getQueueName(), QueueStatus.Deleting)) {
+            logger.with("definition", definition).success("Marked for deletion");
         }
     }
 
-    private boolean trySetQueueNameAvailableStatus(final QueueDefinition definition, final QueueStatus status) {
-        final Statement update =
-                QueryBuilder.update(Tables.QueueNameManager.TABLE_NAME)
-                            .where(eq(Tables.QueueNameManager.QUEUE_NAME, definition.getQueueName().get()))
-                            .with(set(Tables.QueueNameManager.STATUS, status.ordinal()))
-                            .onlyIf(eq(Tables.QueueNameManager.VERSION, definition.getVersion()));
-
-        return session.execute(update).wasApplied();
-    }
 
     @Override
-    public void createQueue(@NonNull final QueueDefinition definition) throws QueueExistsError {
-        insertQueueRecord(definition);
-
-        initializeMonotonicValue(definition.getId());
-
-        initializePointers(definition.getId());
+    public boolean createQueue(@NonNull final QueueDefinition definition) {
+        return upsertQueueDefinition(definition);
     }
 
     /**
      * Set the status but only if its allowed to move to that status
-     * @param queueId
+     *
+     * @param queueName
      * @param status
      */
-    @Override
-    public boolean trySetQueueDefinitionStatus(@NonNull final QueueId queueId, @NonNull final QueueStatus status) {
+    private boolean trySetQueueDefinitionStatus(@NonNull final QueueName queueName, @NonNull final QueueStatus status) {
         final Statement update = QueryBuilder.update(Tables.Queue.TABLE_NAME)
-                                             .where(eq(Tables.Queue.QUEUE_ID, queueId.get()))
+                                             .where(eq(Tables.Queue.QUEUE_NAME, queueName.get()))
                                              .with(set(Tables.Queue.STATUS, status.ordinal()))
                                              .onlyIf(lt(Tables.Queue.STATUS, status.ordinal()));
 
         return session.execute(update).wasApplied();
     }
 
-    private void insertQueueRecord(@NonNull final QueueDefinition queueDefinition) throws QueueExistsError {
-        // if an active queue exists you can't create another one of the same name
-        if (getActiveQueue(queueDefinition.getQueueName()).isPresent()) {
-            throw new QueueExistsError(queueDefinition);
+    private boolean insertQueueIfNotExist(final QueueDefinition queueDefinition) {
+        final Insert insertQueue = QueryBuilder.insertInto(Tables.Queue.TABLE_NAME)
+                                               .ifNotExists()
+                                               .value(Tables.Queue.QUEUE_NAME, queueDefinition.getQueueName().get())
+                                               .value(Tables.Queue.VERSION, 0)
+                                               .value(Tables.Queue.BUCKET_SIZE, queueDefinition.getBucketSize().get())
+                                               .value(Tables.Queue.QUEUE_NAME, queueDefinition.getQueueName().get())
+                                               .value(Tables.Queue.MAX_DELIVERY_COUNT, queueDefinition.getMaxDeliveryCount())
+                                               .value(Tables.Queue.STATUS, QueueStatus.Inactive.ordinal());
+
+        final boolean queueInserted = session.execute(insertQueue).wasApplied();
+
+        if (queueInserted) {
+
+            resetQueueMonotonicValue(queueDefinition.getQueueName());
+
+            resetQueuePointers(queueDefinition.getQueueName());
+
+            return trySetQueueDefinitionStatus(queueDefinition.getQueueName(), QueueStatus.Active);
         }
+
+        return false;
+    }
+
+    private boolean upsertQueueDefinition(@NonNull final QueueDefinition queueDefinition) {
+
+        if (insertQueueIfNotExist(queueDefinition)) {
+            // easy/happy path. nothing was there before
+            return true;
+        }
+
+
+        final Optional<QueueDefinition> currentQueueDefinitionOption = getQueue(queueDefinition.getQueueName());
+
+        if (!currentQueueDefinitionOption.isPresent()) {
+            throw new RuntimeException("this should be impossible because we just inserted the queue");
+        }
+
+        final QueueDefinition currentQueueDefinition = currentQueueDefinitionOption.get();
+
+        if (currentQueueDefinition.getStatus() != QueueStatus.Inactive) {
+            return false;
+        }
+
 
         // if however, an inactve queue exists, make sure only one person can
         // create the next active queue (prevent race conditions of multiple queues being created
         // of the same name that are active
         // first check the table name version table
-        final Select.Where activeQueueIdSelect = QueryBuilder.select()
-                                                             .column(Tables.QueueNameManager.VERSION)
-                                                             .from(Tables.QueueNameManager.TABLE_NAME)
-                                                             .where(eq(Tables.QueueNameManager.QUEUE_NAME, queueDefinition.getQueueName().get()));
 
-        final Row row = session.execute(activeQueueIdSelect).one();
 
-        int currentVersion;
-
-        if (row == null) {
-            currentVersion = seedQueueNameIdGeneratorTable(queueDefinition);
-        }
-        else {
-            currentVersion = row.getInt(0);
-        }
-
+        final int currentVersion = currentQueueDefinition.getVersion();
         final int nextVersion = currentVersion + 1;
 
         // update the tracking table to see who can grab the next version
         // only if the queue name status is inactive
         // if its available grab it
-        final Statement insertTrackingId = QueryBuilder.update(Tables.QueueNameManager.TABLE_NAME)
-                                                       .where(eq(Tables.QueueNameManager.QUEUE_NAME, queueDefinition.getQueueName().get()))
-                                                       .with(set(Tables.QueueNameManager.VERSION, nextVersion))
+        final Statement insertTrackingId = QueryBuilder.update(Tables.Queue.TABLE_NAME)
+                                                       .where(eq(Tables.Queue.QUEUE_NAME, queueDefinition.getQueueName().get()))
+                                                       .with(set(Tables.Queue.VERSION, nextVersion))
                                                        .and(set(Tables.Queue.STATUS, QueueStatus.Active.ordinal()))
-                                                       .onlyIf(eq(Tables.QueueNameManager.VERSION, currentVersion))
-                                                       .and(eq(Tables.QueueNameManager.STATUS, QueueStatus.Inactive.ordinal()));
+                                                       .and(set(Tables.Queue.BUCKET_SIZE, queueDefinition.getBucketSize()))
+                                                       .and(set(Tables.Queue.MAX_DELIVERY_COUNT, queueDefinition.getMaxDeliveryCount()))
+                                                       .onlyIf(eq(Tables.Queue.VERSION, currentVersion))
+                                                       .and(eq(Tables.Queue.STATUS, QueueStatus.Inactive.ordinal()));
 
-        if (!session.execute(insertTrackingId).wasApplied()) {
-            throw new QueueExistsError(queueDefinition);
-        }
-
-        final QueueId queueId = QueueId.valueOf(queueDefinition.getQueueName(), nextVersion);
-
-        // if we're still the one who grabbed the version then insert into the table
-        final Insert insertQueue = QueryBuilder.insertInto(Tables.Queue.TABLE_NAME)
-                                               .ifNotExists()
-                                               .value(Tables.Queue.QUEUE_ID, queueId.get())
-                                               .value(Tables.Queue.VERSION, nextVersion)
-                                               .value(Tables.Queue.BUCKET_SIZE, queueDefinition.getBucketSize().get())
-                                               .value(Tables.Queue.QUEUE_NAME, queueDefinition.getQueueName().get())
-                                               .value(Tables.Queue.MAX_DELIVERY_COUNT, queueDefinition.getMaxDeliveryCount())
-                                               .value(Tables.Queue.STATUS, QueueStatus.Active.ordinal());
-
-        if (!session.execute(insertQueue).wasApplied()) {
-            throw new QueueExistsError(queueDefinition);
-        }
-
-        queueDefinition.setId(queueId);
-
-        queueDefinition.setVersion(nextVersion);
+        final boolean queueUpdateApplied = session.execute(insertTrackingId).wasApplied();
 
         logger.with(queueDefinition).success("Created queue");
+
+        return queueUpdateApplied;
     }
 
-    /**
-     * Inserts the queue definition into the tracking table if no queue with this name was ever made
-     *
-     * @param queueDefinition
-     */
-    private int seedQueueNameIdGeneratorTable(@NonNull final QueueDefinition queueDefinition) throws QueueExistsError {
+    private void resetQueuePointers(@NonNull final QueueName queueName) {
 
-        final int initialVersion = 0;
-
-        final Statement value = QueryBuilder.insertInto(Tables.QueueNameManager.TABLE_NAME)
-                                            .ifNotExists()
-                                            .value(Tables.QueueNameManager.QUEUE_NAME, queueDefinition.getQueueName().get())
-                                            .value(Tables.QueueNameManager.STATUS, QueueStatus.Inactive.ordinal())
-                                            .value(Tables.QueueNameManager.VERSION, initialVersion);
-
-
-        if (!session.execute(value).wasApplied()) {
-            throw new QueueExistsError(queueDefinition);
-        }
-
-        logger.with("queue-name", queueDefinition.getQueueName())
-              .debug("Seeding queue tracking table for new queue name");
-
-        return initialVersion;
+        initializePointer(queueName, PointerType.BUCKET_POINTER, 0L);
+        initializePointer(queueName, PointerType.INVISIBILITY_POINTER, -1L);
+        initializePointer(queueName, PointerType.REPAIR_BUCKET, 0L);
     }
 
-    private void initializePointers(@NonNull final QueueId queueId) {
-
-        initializePointer(queueId, PointerType.BUCKET_POINTER, 0L);
-        initializePointer(queueId, PointerType.INVISIBILITY_POINTER, -1L);
-        initializePointer(queueId, PointerType.REPAIR_BUCKET, 0L);
-    }
-
-    private void initializeMonotonicValue(@NonNull final QueueId queueId) {
+    private void resetQueueMonotonicValue(@NonNull final QueueName queueName) {
         Statement statement = QueryBuilder.insertInto(Tables.Monoton.TABLE_NAME)
-                                          .value(Tables.Monoton.QUEUE_ID, queueId.get())
+                                          .ifNotExists()
+                                          .value(Tables.Monoton.QUEUE_NAME, queueName.get())
                                           .value(Tables.Monoton.VALUE, 0L)
                                           .ifNotExists();
 
-        session.execute(statement);
+        final boolean valueInserted = session.execute(statement).wasApplied();
+
+        if (!valueInserted) {
+            // get + update to 0
+        }
     }
 
-    private void initializePointer(@NonNull final QueueId queueId, @NonNull final PointerType pointerType, @NonNull final Long value) {
+    private void initializePointer(@NonNull final QueueName queueName, @NonNull final PointerType pointerType, @NonNull final Long value) {
         final Statement insert = QueryBuilder.insertInto(Tables.Pointer.TABLE_NAME)
                                              .ifNotExists()
                                              .value(Tables.Pointer.VALUE, value)
-                                             .value(Tables.Pointer.QUEUE_ID, queueId.get())
+                                             .value(Tables.Pointer.QUEUE_NAME, queueName.get())
                                              .value(Tables.Pointer.POINTER_TYPE, pointerType.toString());
 
-        session.execute(insert);
+        final boolean valueInserted = session.execute(insert).wasApplied();
+
+        if (!valueInserted) {
+            // get + update to 0
+        }
     }
 
     @Override
-    public boolean queueExists(@NonNull final QueueName queueName) {
-        return getActiveQueue(queueName).isPresent();
-    }
-
-    @Override
-    public Optional<QueueDefinition> getQueue(@NonNull final QueueId queueId) {
+    public Optional<QueueDefinition> getQueue(@NonNull final QueueName queueName) {
         final Select.Where queryOne =
                 QueryBuilder.select().all()
                             .from(Tables.Queue.TABLE_NAME)
-                            .where(eq(Tables.Queue.QUEUE_ID, queueId.get()));
+                            .where(eq(Tables.Queue.QUEUE_NAME, queueName.get()));
 
         final QueueDefinition result = getOne(session.execute(queryOne), QueueDefinition::fromRow);
 
@@ -231,44 +199,20 @@ public class QueueRepositoryImpl extends RepositoryBase implements QueueReposito
 
     @Override
     public Optional<QueueDefinition> getActiveQueue(final QueueName name) {
-        final Statement highestVersion = QueryBuilder.select(Tables.QueueNameManager.VERSION)
-                                                     .from(Tables.QueueNameManager.TABLE_NAME)
-                                                     .where(eq(Tables.QueueNameManager.QUEUE_NAME, name.get()));
+        final Optional<QueueDefinition> queue = getQueue(name);
 
-        final Row result = session.execute(highestVersion).one();
-
-        if (result == null) {
-            return Optional.empty();
-        }
-
-        final int activeVersion = result.getInt(Tables.QueueNameManager.VERSION);
-
-        final Optional<QueueDefinition> queue = getQueue(QueueId.valueOf(name, activeVersion));
-
-        if (queue.isPresent() && queue.get().getStatus() == QueueStatus.Active) {
-            return queue;
-        }
-
-        return Optional.empty();
+        return queue.filter(queueDef -> queueDef.getStatus() == QueueStatus.Active);
     }
 
     @Override
     public boolean tryDeleteQueueDefinition(@NonNull final QueueDefinition definition) {
         final Update.Conditions updateTrackingTable =
-                QueryBuilder.update(Tables.QueueNameManager.TABLE_NAME)
-                            .where(eq(Tables.QueueNameManager.QUEUE_NAME, definition.getQueueName().get()))
-                            .with(set(Tables.QueueNameManager.STATUS, QueueStatus.Inactive.ordinal()))
-                            .onlyIf(eq(Tables.QueueNameManager.VERSION, definition.getVersion()))
-                            .and(eq(Tables.QueueNameManager.STATUS, QueueStatus.Active.ordinal()));
+                QueryBuilder.update(Tables.Queue.TABLE_NAME)
+                            .where(eq(Tables.Queue.QUEUE_NAME, definition.getQueueName().get()))
+                            .with(set(Tables.Queue.STATUS, QueueStatus.Inactive.ordinal()))
+                            .onlyIf(eq(Tables.Queue.VERSION, definition.getVersion()))
+                            .and(eq(Tables.Queue.STATUS, QueueStatus.Active.ordinal()));
 
-        if (!session.execute(updateTrackingTable).wasApplied()) {
-            return false;
-        }
-
-        Statement delete = QueryBuilder.delete().all()
-                                       .from(Tables.Queue.TABLE_NAME)
-                                       .where(eq(Tables.Queue.QUEUE_ID, definition.getId().get()));
-
-        return session.execute(delete).wasApplied();
+        return session.execute(updateTrackingTable).wasApplied();
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/QueueRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/QueueRepositoryImpl.java
@@ -56,7 +56,7 @@ public class QueueRepositoryImpl extends RepositoryBase implements QueueReposito
      * @param queueName
      * @param status
      */
-    private boolean trySetQueueDefinitionStatus(@NonNull final QueueName queueName, @NonNull final QueueStatus status) {
+    public boolean trySetQueueDefinitionStatus(@NonNull final QueueName queueName, @NonNull final QueueStatus status) {
         final Statement update = QueryBuilder.update(Tables.Queue.TABLE_NAME)
                                              .where(eq(Tables.Queue.QUEUE_NAME, queueName.get()))
                                              .with(set(Tables.Queue.STATUS, status.ordinal()))
@@ -71,7 +71,6 @@ public class QueueRepositoryImpl extends RepositoryBase implements QueueReposito
                                                .value(Tables.Queue.QUEUE_NAME, queueDefinition.getQueueName().get())
                                                .value(Tables.Queue.VERSION, 0)
                                                .value(Tables.Queue.BUCKET_SIZE, queueDefinition.getBucketSize().get())
-                                               .value(Tables.Queue.QUEUE_NAME, queueDefinition.getQueueName().get())
                                                .value(Tables.Queue.MAX_DELIVERY_COUNT, queueDefinition.getMaxDeliveryCount())
                                                .value(Tables.Queue.STATUS, QueueStatus.Inactive.ordinal());
 
@@ -126,7 +125,7 @@ public class QueueRepositoryImpl extends RepositoryBase implements QueueReposito
                                                        .where(eq(Tables.Queue.QUEUE_NAME, queueDefinition.getQueueName().get()))
                                                        .with(set(Tables.Queue.VERSION, nextVersion))
                                                        .and(set(Tables.Queue.STATUS, QueueStatus.Active.ordinal()))
-                                                       .and(set(Tables.Queue.BUCKET_SIZE, queueDefinition.getBucketSize()))
+                                                       .and(set(Tables.Queue.BUCKET_SIZE, queueDefinition.getBucketSize().get()))
                                                        .and(set(Tables.Queue.MAX_DELIVERY_COUNT, queueDefinition.getMaxDeliveryCount()))
                                                        .onlyIf(eq(Tables.Queue.VERSION, currentVersion))
                                                        .and(eq(Tables.Queue.STATUS, QueueStatus.Inactive.ordinal()));

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/QueueRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/QueueRepositoryImpl.java
@@ -1,14 +1,17 @@
 package io.paradoxical.cassieq.dataAccess;
 
+import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
 import com.google.inject.Inject;
+import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.model.PointerType;
 import io.paradoxical.cassieq.model.QueueDefinition;
+import io.paradoxical.cassieq.model.QueueId;
 import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.QueueStatus;
 import lombok.NonNull;
@@ -30,56 +33,118 @@ public class QueueRepositoryImpl extends RepositoryBase implements QueueReposito
     }
 
     @Override
-    public void createQueue(@NonNull final QueueDefinition definition) {
-
-        initializeMonotonicValue(definition.getQueueName());
-
-        initializePointers(definition.getQueueName());
-
+    public void createQueue(@NonNull final QueueDefinition definition) throws QueueExistsError {
         insertQueueRecord(definition);
+
+        initializeMonotonicValue(definition.getId());
+
+        initializePointers(definition.getId());
     }
 
     @Override
-    public void setQueueStatus(@NonNull final QueueName queueName, @NonNull final QueueStatus status) {
+    public void setQueueStatus(@NonNull final QueueId queueId, @NonNull final QueueStatus status) {
         final Statement update = QueryBuilder.update(Tables.Queue.TABLE_NAME)
-                                             .where(eq(Tables.Queue.QUEUENAME, queueName.get()))
+                                             .where(eq(Tables.Queue.QUEUE_ID, queueId.get()))
                                              .with(set(Tables.Queue.STATUS, status.name()));
 
         session.execute(update);
     }
 
-    private void insertQueueRecord(@NonNull final QueueDefinition queueDefinition) {
+    private void insertQueueRecord(@NonNull final QueueDefinition queueDefinition) throws QueueExistsError {
+        // if an active queue exists you can't create another one of the same name
+        if (getActiveQueue(queueDefinition.getQueueName()).isPresent()) {
+            throw new QueueExistsError(queueDefinition);
+        }
+
+        // if however, an inactve queue exists, make sure only one person can
+        // create the next active queue (prevent race conditinos of multiple queues being created
+        // of the same name that are active
+        // first check the table name version table
+        final Select.Where activeQueueIdSelect = QueryBuilder.select()
+                                                             .column(Tables.QueueIdIndex.VERSION)
+                                                             .from(Tables.QueueIdIndex.TABLE_NAME)
+                                                             .where(eq(Tables.QueueIdIndex.QUEUE_NAME, queueDefinition.getQueueName().get()));
+
+        final Row row = session.execute(activeQueueIdSelect).one();
+
+        int currentVersion;
+
+        if (row == null) {
+            currentVersion = insertQueueIndexTracking(queueDefinition);
+        }
+        else {
+            currentVersion = session.execute(activeQueueIdSelect).one().getInt(0);
+        }
+
+        final int nextVersion = currentVersion + 1;
+
+        final Statement insertTrackingId = QueryBuilder.insertInto(Tables.QueueIdIndex.TABLE_NAME)
+                                                       .ifNotExists()
+                                                       .value(Tables.QueueIdIndex.QUEUE_NAME, queueDefinition.getQueueName().get())
+                                                       .value(Tables.QueueIdIndex.VERSION, nextVersion);
+
+        if (!session.execute(insertTrackingId).wasApplied()) {
+            throw new QueueExistsError(queueDefinition);
+        }
+
+        final QueueId queueId = QueueId.valueOf(queueDefinition.getQueueName(), nextVersion);
+
         final Insert insertQueue = QueryBuilder.insertInto(Tables.Queue.TABLE_NAME)
                                                .ifNotExists()
-                                               .value(Tables.Queue.QUEUENAME, queueDefinition.getQueueName().get())
+                                               .value(Tables.Queue.QUEUE_ID, queueId.get())
                                                .value(Tables.Queue.BUCKET_SIZE, queueDefinition.getBucketSize().get())
-                                               .value(Tables.Queue.MAX_DEQUEUE_COUNT, queueDefinition.getMaxDeliveryCount())
+                                               .value(Tables.Queue.QUEUE_NAME, queueDefinition.getQueueName().get())
+                                               .value(Tables.Queue.MAX_DELIVERY_COUNT, queueDefinition.getMaxDeliveryCount())
                                                .value(Tables.Queue.STATUS, QueueStatus.Active.name());
 
         session.execute(insertQueue);
+
+        queueDefinition.setId(queueId);
     }
 
-    private void initializePointers(@NonNull final QueueName queueName) {
+    /**
+     * Inserts the queue definition into the tracking table if no queue with this name was ever made
+     *
+     * @param queueDefinition
+     */
+    private int insertQueueIndexTracking(@NonNull final QueueDefinition queueDefinition) throws QueueExistsError {
 
-        initializePointer(queueName, PointerType.BUCKET_POINTER, 0L);
-        initializePointer(queueName, PointerType.INVISIBILITY_POINTER, -1L);
-        initializePointer(queueName, PointerType.REPAIR_BUCKET, 0L);
+        final int initialVersion = 0;
+
+        final Statement value = QueryBuilder.insertInto(Tables.QueueIdIndex.TABLE_NAME)
+                                            .ifNotExists()
+                                            .value(Tables.QueueIdIndex.QUEUE_NAME, queueDefinition.getQueueName().get())
+                                            .value(Tables.QueueIdIndex.VERSION, initialVersion);
+
+
+        if (!session.execute(value).wasApplied()) {
+            throw new QueueExistsError(queueDefinition);
+        }
+
+        return initialVersion;
     }
 
-    private void initializeMonotonicValue(@NonNull final QueueName queueName) {
+    private void initializePointers(@NonNull final QueueId queueId) {
+
+        initializePointer(queueId, PointerType.BUCKET_POINTER, 0L);
+        initializePointer(queueId, PointerType.INVISIBILITY_POINTER, -1L);
+        initializePointer(queueId, PointerType.REPAIR_BUCKET, 0L);
+    }
+
+    private void initializeMonotonicValue(@NonNull final QueueId queueId) {
         Statement statement = QueryBuilder.insertInto(Tables.Monoton.TABLE_NAME)
-                                          .value(Tables.Monoton.QUEUENAME, queueName.get())
+                                          .value(Tables.Monoton.QUEUE_ID, queueId.get())
                                           .value(Tables.Monoton.VALUE, 0L)
                                           .ifNotExists();
 
         session.execute(statement);
     }
 
-    private void initializePointer(@NonNull final QueueName queueName, @NonNull final PointerType pointerType, @NonNull final Long value) {
+    private void initializePointer(@NonNull final QueueId queueId, @NonNull final PointerType pointerType, @NonNull final Long value) {
         final Statement insert = QueryBuilder.insertInto(Tables.Pointer.TABLE_NAME)
                                              .ifNotExists()
                                              .value(Tables.Pointer.VALUE, value)
-                                             .value(Tables.Pointer.QUEUENAME, queueName.get())
+                                             .value(Tables.Pointer.QUEUE_ID, queueId.get())
                                              .value(Tables.Pointer.POINTER_TYPE, pointerType.toString());
 
         session.execute(insert);
@@ -87,36 +152,62 @@ public class QueueRepositoryImpl extends RepositoryBase implements QueueReposito
 
     @Override
     public boolean queueExists(@NonNull final QueueName queueName) {
-        final Select.Where queryOne =
-                QueryBuilder.select().all().from(Tables.Queue.TABLE_NAME).where(eq(Tables.Queue.QUEUENAME, queueName.get()));
-
-        return getOne(session.execute(queryOne), row -> true) != null;
+        return getActiveQueue(queueName).isPresent();
     }
 
     @Override
-    public Optional<QueueDefinition> getQueue(@NonNull final QueueName queueName) {
+    public Optional<QueueDefinition> getQueue(@NonNull final QueueId queueId) {
         final Select.Where queryOne =
-                QueryBuilder.select().all().from(Tables.Queue.TABLE_NAME).where(eq(Tables.Queue.QUEUENAME, queueName.get()));
+                QueryBuilder.select().all()
+                            .from(Tables.Queue.TABLE_NAME)
+                            .where(eq(Tables.Queue.QUEUE_ID, queueId.get()));
 
         final QueueDefinition result = getOne(session.execute(queryOne), QueueDefinition::fromRow);
+
         return Optional.ofNullable(result);
     }
 
     @Override
-    public List<QueueDefinition> getQueues() {
+    public List<QueueDefinition> getActiveQueues() {
         final Select query = QueryBuilder.select().all().from(Tables.Queue.TABLE_NAME);
 
         return session.execute(query)
                       .all()
                       .stream()
-                      .map(QueueDefinition::fromRow).collect(toList());
+                      .map(QueueDefinition::fromRow)
+                      .filter(queue -> queue.getStatus().equals(QueueStatus.Active))
+                      .collect(toList());
     }
 
     @Override
-    public void deleteQueueDefinition(@NonNull final QueueName queueName) {
-        final Statement delete = QueryBuilder.delete().all()
-                                             .from(Tables.Queue.TABLE_NAME)
-                                             .where(eq(Tables.Queue.QUEUENAME, queueName.get()));
+    public Optional<QueueDefinition> getActiveQueue(final QueueName name) {
+        final Select limit = QueryBuilder.select(Tables.QueueIdIndex.VERSION)
+                                         .from(Tables.QueueIdIndex.TABLE_NAME)
+                                         .where(eq(Tables.QueueIdIndex.QUEUE_NAME, name.get()))
+                                         .limit(1);
+
+        final Row result = session.execute(limit).one();
+
+        if (result == null) {
+            return Optional.empty();
+        }
+
+        final int activeVersion = result.getInt(Tables.QueueIdIndex.VERSION);
+
+        final Optional<QueueDefinition> queue = getQueue(QueueId.valueOf(name, activeVersion));
+
+        if (queue.isPresent() && queue.get().getStatus() == QueueStatus.Active) {
+            return queue;
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public void deleteQueueDefinition(@NonNull final QueueDefinition definition) {
+        Statement delete = QueryBuilder.delete().all()
+                                       .from(Tables.Queue.TABLE_NAME)
+                                       .where(eq(Tables.Queue.QUEUE_ID, definition.getId().get()));
 
         session.execute(delete);
     }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
@@ -4,32 +4,24 @@ package io.paradoxical.cassieq.dataAccess;
 public final class Tables {
     public static class Pointer {
         public static final String TABLE_NAME = "pointer";
-        public static final String QUEUE_ID = "queueid";
+        public static final String QUEUE_NAME = "queuename";
         public static final String POINTER_TYPE = "pointer_type";
         public static final String VALUE = "value";
     }
 
     public static class Monoton {
         public static final String TABLE_NAME = "monoton";
-        public static final String QUEUE_ID = "queueid";
+        public static final String QUEUE_NAME = "queuename";
         public static final String VALUE = "value";
     }
 
     public static class Queue {
         public static final String TABLE_NAME = "queue";
-        public static final String QUEUE_ID = "queueid";
         public static final String MAX_DELIVERY_COUNT = "max_delivery_count";
         public static final String BUCKET_SIZE = "bucket_size";
         public static final String STATUS = "status";
         public static final String QUEUE_NAME = "queuename";
         public static final String VERSION = "version";
-    }
-
-    public static class QueueNameManager {
-        public static final String TABLE_NAME = "queue_name_manager";
-        public static final String QUEUE_NAME = "queuename";
-        public static final String VERSION = "version";
-        public static final String STATUS = "status";
     }
 
     public static class Message {

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
@@ -4,14 +4,14 @@ package io.paradoxical.cassieq.dataAccess;
 public final class Tables {
     public static class Pointer {
         public static final String TABLE_NAME = "pointer";
-        public static final String QUEUE_NAME = "queuename";
+        public static final String QUEUE_ID = "queueid";
         public static final String POINTER_TYPE = "pointer_type";
         public static final String VALUE = "value";
     }
 
     public static class Monoton {
         public static final String TABLE_NAME = "monoton";
-        public static final String QUEUE_NAME = "queuename";
+        public static final String QUEUE_ID = "queueid";
         public static final String VALUE = "value";
     }
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
@@ -25,7 +25,6 @@ public final class Tables {
     }
 
     public static class Message {
-
         public static final String TABLE_NAME = "message";
         public static final String QUEUE_ID = "queueid";
         public static final String BUCKET_NUM = "bucket_num";
@@ -37,5 +36,12 @@ public final class Tables {
         public static final String NEXT_VISIBLE_ON = "next_visible_on";
         public static final String CREATED_DATE = "created_date";
         public static final String TAG = "tag";
+    }
+
+    public static class DeletionJob {
+        public static final String TABLE_NAME = "deletion_job";
+        public static final String QUEUE_NAME = "queuename";
+        public static final String VERSION = "version";
+        public static final String BUCKET_SIZE = "bucket_size";
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
@@ -22,12 +22,14 @@ public final class Tables {
         public static final String BUCKET_SIZE = "bucket_size";
         public static final String STATUS = "status";
         public static final String QUEUE_NAME = "queuename";
+        public static final String VERSION = "version";
     }
 
     public static class QueueIdIndex {
         public static final String TABLE_NAME = "queue_name_idx";
         public static final String QUEUE_NAME = "queuename";
         public static final String VERSION = "version";
+        public static final String STATUS = "status";
     }
 
     public static class Message {

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
@@ -25,8 +25,8 @@ public final class Tables {
         public static final String VERSION = "version";
     }
 
-    public static class QueueIdIndex {
-        public static final String TABLE_NAME = "queue_name_idx";
+    public static class QueueNameManager {
+        public static final String TABLE_NAME = "queue_name_manager";
         public static final String QUEUE_NAME = "queuename";
         public static final String VERSION = "version";
         public static final String STATUS = "status";

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
@@ -1,31 +1,39 @@
 package io.paradoxical.cassieq.dataAccess;
 
+
 public final class Tables {
     public static class Pointer {
         public static final String TABLE_NAME = "pointer";
-        public static final String QUEUENAME = "queuename";
+        public static final String QUEUE_ID = "queueid";
         public static final String POINTER_TYPE = "pointer_type";
         public static final String VALUE = "value";
     }
 
     public static class Monoton {
         public static final String TABLE_NAME = "monoton";
-        public static final String QUEUENAME = "queuename";
+        public static final String QUEUE_ID = "queueid";
         public static final String VALUE = "value";
     }
 
     public static class Queue {
         public static final String TABLE_NAME = "queue";
-        public static final String QUEUENAME = "queuename";
-        public static final String MAX_DEQUEUE_COUNT = "max_dequeue_count";
+        public static final String QUEUE_ID = "queueid";
+        public static final String MAX_DELIVERY_COUNT = "max_delivery_count";
         public static final String BUCKET_SIZE = "bucket_size";
         public static final String STATUS = "status";
+        public static final String QUEUE_NAME = "queuename";
+    }
+
+    public static class QueueIdIndex {
+        public static final String TABLE_NAME = "queue_name_idx";
+        public static final String QUEUE_NAME = "queuename";
+        public static final String VERSION = "version";
     }
 
     public static class Message {
 
         public static final String TABLE_NAME = "message";
-        public static final String QUEUENAME = "queuename";
+        public static final String QUEUE_ID = "queueid";
         public static final String BUCKET_NUM = "bucket_num";
         public static final String MONOTON = "monoton";
         public static final String MESSAGE = "message";

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/exceptions/QueueAlreadyDeletingException.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/exceptions/QueueAlreadyDeletingException.java
@@ -1,0 +1,9 @@
+package io.paradoxical.cassieq.dataAccess.exceptions;
+
+import io.paradoxical.cassieq.model.QueueDefinition;
+
+public class QueueAlreadyDeletingException extends Exception {
+    public QueueAlreadyDeletingException(final QueueDefinition queueDefinition) {
+        super("Queue already deleting: " + queueDefinition.toString());
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/exceptions/QueueExistsError.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/exceptions/QueueExistsError.java
@@ -1,0 +1,9 @@
+package io.paradoxical.cassieq.dataAccess.exceptions;
+
+import io.paradoxical.cassieq.model.QueueDefinition;
+
+public class QueueExistsError extends Exception {
+    public QueueExistsError(final QueueDefinition queueDefinition) {
+        super("Queue already exists: " + queueDefinition.toString());
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/exceptions/QueueExistsException.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/exceptions/QueueExistsException.java
@@ -2,8 +2,8 @@ package io.paradoxical.cassieq.dataAccess.exceptions;
 
 import io.paradoxical.cassieq.model.QueueDefinition;
 
-public class QueueExistsError extends Exception {
-    public QueueExistsError(final QueueDefinition queueDefinition) {
+public class QueueExistsException extends Exception {
+    public QueueExistsException(final QueueDefinition queueDefinition) {
         super("Queue already exists: " + queueDefinition.toString());
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/MessageDeletorJobProcessor.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/MessageDeletorJobProcessor.java
@@ -1,0 +1,5 @@
+package io.paradoxical.cassieq.dataAccess.interfaces;
+
+public interface MessageDeletorJobProcessor {
+    void start();
+}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/MessageRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/MessageRepository.java
@@ -37,6 +37,4 @@ public interface MessageRepository {
     Optional<DateTime> tombstoneExists(final BucketPointer bucketPointer);
 
     void deleteAllMessages(BucketPointer bucket);
-
-    void deleteAllMessages(MessagePointer from, MessagePointer to);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -12,9 +12,24 @@ import java.util.Optional;
 import static java.util.stream.Collectors.toList;
 
 public interface QueueRepository {
+
+    /**
+     * Marks this queue id for deletion and makes the queue name available for creation by someone else
+     * @param definition
+     */
+    void markForDeletion(QueueDefinition definition);
+
+    /**
+     * Attemps to create a queue with this name
+     * @param definition
+     * @throws QueueExistsError
+     */
     void createQueue(QueueDefinition definition) throws QueueExistsError;
 
-    void setQueueStatus(QueueId queueId, final QueueStatus status);
+    /**
+     * Sets the queue definition status if is possible set (some states cannot be gone back to)
+     */
+    boolean trySetQueueDefinitionStatus(QueueId queueId, final QueueStatus status);
 
     boolean queueExists(QueueName queueName);
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -24,16 +24,9 @@ public interface QueueRepository {
      * @param definition
      * @throws QueueExistsError
      */
-    void createQueue(QueueDefinition definition) throws QueueExistsError;
+    boolean createQueue(QueueDefinition definition);
 
-    /**
-     * Sets the queue definition status if is possible set (some states cannot be gone back to)
-     */
-    boolean trySetQueueDefinitionStatus(QueueId queueId, final QueueStatus status);
-
-    boolean queueExists(QueueName queueName);
-
-    Optional<QueueDefinition> getQueue(QueueId queueId);
+    Optional<QueueDefinition> getQueue(QueueName queueId);
 
     List<QueueDefinition> getActiveQueues();
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -1,7 +1,10 @@
 package io.paradoxical.cassieq.dataAccess.interfaces;
 
+import io.paradoxical.cassieq.dataAccess.DeletionJob;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueName;
+import io.paradoxical.cassieq.model.QueueStatus;
+import lombok.NonNull;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,25 +15,33 @@ public interface QueueRepository {
 
     /**
      * Marks this queue id for deletion and makes the queue name available for creation by someone else
+     *
      * @param definition
      */
-    boolean tryMarkForDeletion(QueueDefinition definition);
+    Optional<DeletionJob> tryMarkForDeletion(QueueDefinition definition);
 
     /**
      * Attemps to create a queue with this name
+     *
      * @param definition
      */
     boolean createQueue(QueueDefinition definition);
 
-    Optional<QueueDefinition> getQueue(QueueName queueId);
+    boolean tryAdvanceQueueStatus(
+            @NonNull QueueName queueName,
+            @NonNull QueueStatus status);
+
+    boolean deleteIfInActive(QueueName queueName);
+
+    Optional<QueueDefinition> getQueueUnsafe(QueueName queueId);
 
     List<QueueDefinition> getActiveQueues();
 
     Optional<QueueDefinition> getActiveQueue(QueueName name);
 
-    boolean tryMarkQueueInactive(QueueDefinition definition);
-
     default List<QueueName> getQueueNames() {
         return getActiveQueues().stream().map(QueueDefinition::getQueueName).collect(toList());
     }
+
+    void deleteCompletionJob(DeletionJob queue);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -22,7 +22,6 @@ public interface QueueRepository {
     /**
      * Attemps to create a queue with this name
      * @param definition
-     * @throws QueueExistsError
      */
     boolean createQueue(QueueDefinition definition);
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -1,6 +1,8 @@
 package io.paradoxical.cassieq.dataAccess.interfaces;
 
+import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.model.QueueDefinition;
+import io.paradoxical.cassieq.model.QueueId;
 import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.QueueStatus;
 
@@ -10,19 +12,21 @@ import java.util.Optional;
 import static java.util.stream.Collectors.toList;
 
 public interface QueueRepository {
-    void createQueue(QueueDefinition definition);
+    void createQueue(QueueDefinition definition) throws QueueExistsError;
 
-    void setQueueStatus(QueueName queueName, final QueueStatus status);
+    void setQueueStatus(QueueId queueId, final QueueStatus status);
 
     boolean queueExists(QueueName queueName);
 
-    Optional<QueueDefinition> getQueue(QueueName queueName);
+    Optional<QueueDefinition> getQueue(QueueId queueId);
 
-    List<QueueDefinition> getQueues();
+    List<QueueDefinition> getActiveQueues();
 
-    void deleteQueueDefinition(QueueName queueName);
+    Optional<QueueDefinition> getActiveQueue(QueueName name);
 
-    default List<QueueName> getQueueNames(){
-        return getQueues().stream().map(QueueDefinition::getQueueName).collect(toList());
+    void deleteQueueDefinition(QueueDefinition definition);
+
+    default List<QueueName> getQueueNames() {
+        return getActiveQueues().stream().map(QueueDefinition::getQueueName).collect(toList());
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -1,10 +1,7 @@
 package io.paradoxical.cassieq.dataAccess.interfaces;
 
-import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.model.QueueDefinition;
-import io.paradoxical.cassieq.model.QueueId;
 import io.paradoxical.cassieq.model.QueueName;
-import io.paradoxical.cassieq.model.QueueStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,7 +14,7 @@ public interface QueueRepository {
      * Marks this queue id for deletion and makes the queue name available for creation by someone else
      * @param definition
      */
-    void markForDeletion(QueueDefinition definition);
+    boolean tryMarkForDeletion(QueueDefinition definition);
 
     /**
      * Attemps to create a queue with this name
@@ -31,7 +28,7 @@ public interface QueueRepository {
 
     Optional<QueueDefinition> getActiveQueue(QueueName name);
 
-    boolean tryDeleteQueueDefinition(QueueDefinition definition);
+    boolean tryMarkQueueInactive(QueueDefinition definition);
 
     default List<QueueName> getQueueNames() {
         return getActiveQueues().stream().map(QueueDefinition::getQueueName).collect(toList());

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -24,7 +24,7 @@ public interface QueueRepository {
 
     Optional<QueueDefinition> getActiveQueue(QueueName name);
 
-    void deleteQueueDefinition(QueueDefinition definition);
+    boolean tryDeleteQueueDefinition(QueueDefinition definition);
 
     default List<QueueName> getQueueNames() {
         return getActiveQueues().stream().map(QueueDefinition::getQueueName).collect(toList());

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -25,7 +25,7 @@ public interface QueueRepository {
      *
      * @param definition
      */
-    boolean createQueue(QueueDefinition definition);
+    Optional<QueueDefinition> createQueue(QueueDefinition definition);
 
     boolean tryAdvanceQueueStatus(
             @NonNull QueueName queueName,
@@ -35,7 +35,11 @@ public interface QueueRepository {
 
     Optional<QueueDefinition> getQueueUnsafe(QueueName queueId);
 
-    List<QueueDefinition> getActiveQueues();
+    default List<QueueDefinition> getActiveQueues(){
+        return getQueues(QueueStatus.Active);
+    }
+
+    List<QueueDefinition> getQueues(QueueStatus queueStatus);
 
     Optional<QueueDefinition> getActiveQueue(QueueName name);
 

--- a/core/src/main/java/io/paradoxical/cassieq/factories/DataContext.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/DataContext.java
@@ -3,16 +3,13 @@ package io.paradoxical.cassieq.factories;
 import io.paradoxical.cassieq.dataAccess.interfaces.MessageRepository;
 import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
 import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
-import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import lombok.Data;
 
 @Data
-public class DataContext{
+public class DataContext {
     private final MessageRepository messageRepository;
 
     private final MonotonicRepository monotonicRepository;
 
     private final PointerRepository pointerRepository;
-
-    private final QueueRepository queueRepository;
 }

--- a/core/src/main/java/io/paradoxical/cassieq/factories/DataContextFactoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/DataContextFactoryImpl.java
@@ -30,8 +30,7 @@ public class DataContextFactoryImpl implements DataContextFactory {
         return new DataContext(
                 messageRepoFactory.forQueue(definition),
                 monotonicRepoFactory.forQueue(definition),
-                pointerRepoFactory.forQueue(definition),
-                queueRepositoryProvider.get());
+                pointerRepoFactory.forQueue(definition));
     }
 
     @Override

--- a/core/src/main/java/io/paradoxical/cassieq/factories/DataContextFactoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/DataContextFactoryImpl.java
@@ -29,14 +29,14 @@ public class DataContextFactoryImpl implements DataContextFactory {
     public DataContext forQueue(QueueDefinition definition) {
         return new DataContext(
                 messageRepoFactory.forQueue(definition),
-                monotonicRepoFactory.forQueue(definition.getQueueName()),
-                pointerRepoFactory.forQueue(definition.getQueueName()),
+                monotonicRepoFactory.forQueue(definition),
+                pointerRepoFactory.forQueue(definition),
                 queueRepositoryProvider.get());
     }
 
     @Override
     public Optional<QueueDefinition> getDefinition(final QueueName name) {
-        return queueRepositoryProvider.get().getQueue(name);
+        return queueRepositoryProvider.get().getActiveQueue(name);
     }
 }
 

--- a/core/src/main/java/io/paradoxical/cassieq/factories/DataContextFactoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/DataContextFactoryImpl.java
@@ -29,8 +29,8 @@ public class DataContextFactoryImpl implements DataContextFactory {
     public DataContext forQueue(QueueDefinition definition) {
         return new DataContext(
                 messageRepoFactory.forQueue(definition),
-                monotonicRepoFactory.forQueue(definition),
-                pointerRepoFactory.forQueue(definition));
+                monotonicRepoFactory.forQueue(definition.getId()),
+                pointerRepoFactory.forQueue(definition.getId()));
     }
 
     @Override

--- a/core/src/main/java/io/paradoxical/cassieq/factories/MessageDeleterJobProcessorFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/MessageDeleterJobProcessorFactory.java
@@ -1,0 +1,8 @@
+package io.paradoxical.cassieq.factories;
+
+import io.paradoxical.cassieq.dataAccess.DeletionJob;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeletorJobProcessor;
+
+public interface MessageDeleterJobProcessorFactory {
+    MessageDeletorJobProcessor createDeletionProcessor(DeletionJob job);
+}

--- a/core/src/main/java/io/paradoxical/cassieq/factories/MessageRepoFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/MessageRepoFactory.java
@@ -4,5 +4,5 @@ import io.paradoxical.cassieq.dataAccess.interfaces.MessageRepository;
 import io.paradoxical.cassieq.model.QueueDefinition;
 
 public interface MessageRepoFactory {
-    MessageRepository forQueue(QueueDefinition queueName);
+    MessageRepository forQueue(QueueDefinition definition);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/factories/MonotonicRepoFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/MonotonicRepoFactory.java
@@ -1,8 +1,8 @@
 package io.paradoxical.cassieq.factories;
 
 import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
-import io.paradoxical.cassieq.model.QueueName;
+import io.paradoxical.cassieq.model.QueueDefinition;
 
-public interface MonotonicRepoFactory{
-    MonotonicRepository forQueue(QueueName queueName);
+public interface MonotonicRepoFactory {
+    MonotonicRepository forQueue(QueueDefinition definition);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/factories/MonotonicRepoFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/MonotonicRepoFactory.java
@@ -1,8 +1,8 @@
 package io.paradoxical.cassieq.factories;
 
 import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
-import io.paradoxical.cassieq.model.QueueDefinition;
+import io.paradoxical.cassieq.model.QueueId;
 
 public interface MonotonicRepoFactory {
-    MonotonicRepository forQueue(QueueDefinition definition);
+    MonotonicRepository forQueue(QueueId queueId);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/factories/PointerRepoFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/PointerRepoFactory.java
@@ -1,9 +1,9 @@
 package io.paradoxical.cassieq.factories;
 
 import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
-import io.paradoxical.cassieq.model.QueueDefinition;
+import io.paradoxical.cassieq.model.QueueId;
 
 public interface PointerRepoFactory {
-    PointerRepository forQueue(QueueDefinition definition);
+    PointerRepository forQueue(QueueId queueId);
 }
 

--- a/core/src/main/java/io/paradoxical/cassieq/factories/PointerRepoFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/PointerRepoFactory.java
@@ -1,9 +1,9 @@
 package io.paradoxical.cassieq.factories;
 
 import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
-import io.paradoxical.cassieq.model.QueueName;
+import io.paradoxical.cassieq.model.QueueDefinition;
 
 public interface PointerRepoFactory {
-    PointerRepository forQueue(QueueName queueName);
+    PointerRepository forQueue(QueueDefinition definition);
 }
 

--- a/core/src/main/java/io/paradoxical/cassieq/model/Message.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/Message.java
@@ -49,7 +49,7 @@ public class Message {
     public boolean isNotTombstone() { return !isTombstone(); }
 
     public PopReceipt getPopReceipt() {
-        return PopReceipt.from(this, queueId);
+        return PopReceipt.from(this);
     }
 
     public Message createNewWithIndex(MonotonicIndex index) {
@@ -64,7 +64,6 @@ public class Message {
                       .tag(tag)
                       .build();
     }
-
 
     public Message withNewVersion(int version) {
         return Message.builder()

--- a/core/src/main/java/io/paradoxical/cassieq/model/Message.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/Message.java
@@ -27,6 +27,8 @@ public class Message {
 
     private MessageTag tag;
 
+    private final QueueId queueId;
+
     public boolean isVisible(Clock clock) {
         return nextVisiblityAt == null || nextVisiblityAt.isBefore(clock.now());
     }
@@ -47,7 +49,7 @@ public class Message {
     public boolean isNotTombstone() { return !isTombstone(); }
 
     public PopReceipt getPopReceipt() {
-        return PopReceipt.from(this);
+        return PopReceipt.from(this, queueId);
     }
 
     public Message createNewWithIndex(MonotonicIndex index) {

--- a/core/src/main/java/io/paradoxical/cassieq/model/PopReceipt.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/PopReceipt.java
@@ -23,14 +23,12 @@ public final class PopReceipt {
 
     private final MessageTag messageTag;
 
-    private final QueueId queueId;
-
     public static PopReceipt valueOf(String string) {
         return parsePopReceipt(string);
     }
 
-    public static PopReceipt from(Message message, QueueId queueId) {
-        return new PopReceipt(message.getIndex(), message.getVersion(), message.getTag(), queueId);
+    public static PopReceipt from(Message message) {
+        return new PopReceipt(message.getIndex(), message.getVersion(), message.getTag());
     }
 
     @Override
@@ -39,7 +37,7 @@ public final class PopReceipt {
     }
 
     private String getPopReceipt() {
-        final String receiptString = String.format("%s:%s:%s:%s", getMessageIndex(), getMessageVersion(), getMessageTag(), getQueueId());
+        final String receiptString = String.format("%s:%s:%s:%s", getMessageIndex(), getMessageVersion(), getMessageTag());
 
         return Base64.getEncoder().withoutPadding().encodeToString(receiptString.getBytes());
     }
@@ -54,22 +52,22 @@ public final class PopReceipt {
         final MonotonicIndex monotonicIndex = MonotonicIndex.valueOf(Long.parseLong(components[0]));
         final Integer messageVersion = Integer.parseInt(components[1]);
         final MessageTag messageTag = MessageTag.valueOf(components[2]);
-        final QueueId queueId = QueueId.valueOf(components[3]);
 
-        return new PopReceipt(monotonicIndex, messageVersion, messageTag, queueId);
+        return new PopReceipt(monotonicIndex, messageVersion, messageTag);
     }
-
 
     public static class JsonDeserializeAdapater extends JsonDeserializer<PopReceipt> {
 
-        @Override public PopReceipt deserialize(final JsonParser jp, final DeserializationContext ctxt)
+        @Override
+        public PopReceipt deserialize(final JsonParser jp, final DeserializationContext ctxt)
                 throws IOException {
             return PopReceipt.valueOf(jp.getValueAsString());
         }
     }
 
     public static class JsonSerializeAdapter extends JsonSerializer<PopReceipt> {
-        @SuppressWarnings("ConstantConditions") @Override
+        @SuppressWarnings("ConstantConditions")
+        @Override
         public void serialize(final PopReceipt value, final JsonGenerator jgen, final SerializerProvider provider)
                 throws IOException {
             jgen.writeString(value.getPopReceipt());

--- a/core/src/main/java/io/paradoxical/cassieq/model/PopReceipt.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/PopReceipt.java
@@ -23,12 +23,14 @@ public final class PopReceipt {
 
     private final MessageTag messageTag;
 
+    private final QueueId queueId;
+
     public static PopReceipt valueOf(String string) {
         return parsePopReceipt(string);
     }
 
-    public static PopReceipt from(Message message) {
-        return new PopReceipt(message.getIndex(), message.getVersion(), message.getTag());
+    public static PopReceipt from(Message message, QueueId queueId) {
+        return new PopReceipt(message.getIndex(), message.getVersion(), message.getTag(), queueId);
     }
 
     @Override
@@ -37,7 +39,7 @@ public final class PopReceipt {
     }
 
     private String getPopReceipt() {
-        final String receiptString = String.format("%s:%s:%s", getMessageIndex(), getMessageVersion(), getMessageTag());
+        final String receiptString = String.format("%s:%s:%s:%s", getMessageIndex(), getMessageVersion(), getMessageTag(), getQueueId());
 
         return Base64.getEncoder().withoutPadding().encodeToString(receiptString.getBytes());
     }
@@ -52,8 +54,9 @@ public final class PopReceipt {
         final MonotonicIndex monotonicIndex = MonotonicIndex.valueOf(Long.parseLong(components[0]));
         final Integer messageVersion = Integer.parseInt(components[1]);
         final MessageTag messageTag = MessageTag.valueOf(components[2]);
+        final QueueId queueId = QueueId.valueOf(components[3]);
 
-        return new PopReceipt(monotonicIndex, messageVersion, messageTag);
+        return new PopReceipt(monotonicIndex, messageVersion, messageTag, queueId);
     }
 
 

--- a/core/src/main/java/io/paradoxical/cassieq/model/PopReceipt.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/PopReceipt.java
@@ -37,7 +37,7 @@ public final class PopReceipt {
     }
 
     private String getPopReceipt() {
-        final String receiptString = String.format("%s:%s:%s:%s", getMessageIndex(), getMessageVersion(), getMessageTag());
+        final String receiptString = String.format("%s:%s:%s", getMessageIndex(), getMessageVersion(), getMessageTag());
 
         return Base64.getEncoder().withoutPadding().encodeToString(receiptString.getBytes());
     }

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
@@ -5,8 +5,6 @@ import io.paradoxical.cassieq.dataAccess.Tables;
 import lombok.Builder;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
-
 @Data
 @Builder
 public class QueueDefinition {

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
@@ -14,25 +14,23 @@ public class QueueDefinition {
     private final BucketSize bucketSize;
     private final Integer maxDeliveryCount;
     private final QueueStatus status;
-
     @NotNull
     private QueueId id;
+    private Integer version;
+
     public QueueDefinition(
             QueueName queueName,
             BucketSize bucketSize,
             Integer maxDeliveryCount,
             QueueStatus status,
-            QueueId id) {
+            QueueId id,
+            Integer version) {
         this.queueName = queueName;
         this.id = id;
+        this.version = version == null ? 0 : version;
         this.bucketSize = bucketSize == null ? BucketSize.valueOf(20) : bucketSize;
         this.maxDeliveryCount = maxDeliveryCount == null ? 5 : maxDeliveryCount;
         this.status = status == null ? QueueStatus.Active : status;
-        this.id = id;
-    }
-
-    private QueueDefinition(QueueName queueName, Integer bucketSize, Integer maxDeliveryCount, QueueStatus status, QueueId id) {
-        this(queueName, BucketSize.valueOf(bucketSize), maxDeliveryCount, status, id);
     }
 
     public static QueueDefinition fromRow(final Row row) {
@@ -42,10 +40,7 @@ public class QueueDefinition {
                               .id(QueueId.valueOf(row.getString(Tables.Queue.QUEUE_ID)))
                               .status(QueueStatus.valueOf(row.getString(Tables.Queue.STATUS)))
                               .queueName(QueueName.valueOf(row.getString(Tables.Queue.QUEUE_NAME)))
+                              .version(row.getInt(Tables.Queue.VERSION))
                               .build();
-    }
-
-    public int getVersion(){
-        return id.getVersion(queueName);
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
@@ -14,19 +14,19 @@ public class QueueDefinition {
     private final BucketSize bucketSize;
     private final Integer maxDeliveryCount;
     private final QueueStatus status;
-    @NotNull
-    private QueueId id;
-    private Integer version;
+    private final int version;
+
+    public QueueId getId() {
+        return QueueId.valueOf(queueName, version);
+    }
 
     public QueueDefinition(
             QueueName queueName,
             BucketSize bucketSize,
             Integer maxDeliveryCount,
             QueueStatus status,
-            QueueId id,
             Integer version) {
         this.queueName = queueName;
-        this.id = id;
         this.version = version == null ? 0 : version;
         this.bucketSize = bucketSize == null ? BucketSize.valueOf(20) : bucketSize;
         this.maxDeliveryCount = maxDeliveryCount == null ? 5 : maxDeliveryCount;
@@ -37,7 +37,6 @@ public class QueueDefinition {
         return QueueDefinition.builder()
                               .bucketSize(BucketSize.valueOf(row.getInt(Tables.Queue.BUCKET_SIZE)))
                               .maxDeliveryCount(row.getInt(Tables.Queue.MAX_DELIVERY_COUNT))
-                              .id(QueueId.valueOf(row.getString(Tables.Queue.QUEUE_ID)))
                               .status(QueueStatus.values()[row.getInt(Tables.Queue.STATUS)])
                               .queueName(QueueName.valueOf(row.getString(Tables.Queue.QUEUE_NAME)))
                               .version(row.getInt(Tables.Queue.VERSION))

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
@@ -38,7 +38,7 @@ public class QueueDefinition {
                               .bucketSize(BucketSize.valueOf(row.getInt(Tables.Queue.BUCKET_SIZE)))
                               .maxDeliveryCount(row.getInt(Tables.Queue.MAX_DELIVERY_COUNT))
                               .id(QueueId.valueOf(row.getString(Tables.Queue.QUEUE_ID)))
-                              .status(QueueStatus.valueOf(row.getString(Tables.Queue.STATUS)))
+                              .status(QueueStatus.values()[row.getInt(Tables.Queue.STATUS)])
                               .queueName(QueueName.valueOf(row.getString(Tables.Queue.QUEUE_NAME)))
                               .version(row.getInt(Tables.Queue.VERSION))
                               .build();

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueDefinition.java
@@ -4,38 +4,48 @@ import com.datastax.driver.core.Row;
 import io.paradoxical.cassieq.dataAccess.Tables;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NonNull;
 
 import javax.validation.constraints.NotNull;
 
 @Data
 @Builder
 public class QueueDefinition {
-    @NotNull
-    @NonNull
-    private final QueueName queueName;
+    private QueueName queueName;
     private final BucketSize bucketSize;
     private final Integer maxDeliveryCount;
-
     private final QueueStatus status;
 
-    public QueueDefinition(QueueName queueName, BucketSize bucketSize, Integer maxDeliveryCount, QueueStatus status) {
+    @NotNull
+    private QueueId id;
+    public QueueDefinition(
+            QueueName queueName,
+            BucketSize bucketSize,
+            Integer maxDeliveryCount,
+            QueueStatus status,
+            QueueId id) {
         this.queueName = queueName;
+        this.id = id;
         this.bucketSize = bucketSize == null ? BucketSize.valueOf(20) : bucketSize;
         this.maxDeliveryCount = maxDeliveryCount == null ? 5 : maxDeliveryCount;
         this.status = status == null ? QueueStatus.Active : status;
+        this.id = id;
     }
 
-    private QueueDefinition(QueueName queueName, Integer bucketSize, Integer maxDeliveryCount, QueueStatus status) {
-        this(queueName, BucketSize.valueOf(bucketSize), maxDeliveryCount, status);
+    private QueueDefinition(QueueName queueName, Integer bucketSize, Integer maxDeliveryCount, QueueStatus status, QueueId id) {
+        this(queueName, BucketSize.valueOf(bucketSize), maxDeliveryCount, status, id);
     }
 
     public static QueueDefinition fromRow(final Row row) {
         return QueueDefinition.builder()
                               .bucketSize(BucketSize.valueOf(row.getInt(Tables.Queue.BUCKET_SIZE)))
-                              .maxDeliveryCount(row.getInt(Tables.Queue.MAX_DEQUEUE_COUNT))
-                              .queueName(QueueName.valueOf(row.getString(Tables.Queue.QUEUENAME)))
+                              .maxDeliveryCount(row.getInt(Tables.Queue.MAX_DELIVERY_COUNT))
+                              .id(QueueId.valueOf(row.getString(Tables.Queue.QUEUE_ID)))
                               .status(QueueStatus.valueOf(row.getString(Tables.Queue.STATUS)))
+                              .queueName(QueueName.valueOf(row.getString(Tables.Queue.QUEUE_NAME)))
                               .build();
+    }
+
+    public int getVersion(){
+        return id.getVersion(queueName);
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueId.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueId.java
@@ -1,0 +1,70 @@
+package io.paradoxical.cassieq.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.paradoxical.common.valuetypes.StringValue;
+import io.paradoxical.common.valuetypes.adapters.xml.JaxbStringValueAdapter;
+import jdk.nashorn.internal.ir.annotations.Immutable;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.io.IOException;
+
+@Immutable
+@XmlJavaTypeAdapter(value = QueueId.XmlAdapter.class)
+@JsonSerialize(using = QueueId.JsonSerializeAdapter.class)
+@JsonDeserialize(using = QueueId.JsonDeserializeAdapater.class)
+public final class QueueId extends StringValue {
+    protected QueueId(final String value) {
+        super(value);
+    }
+
+    public static QueueId valueOf(String value) {
+        return new QueueId(StringUtils.trimToEmpty(value));
+    }
+
+    public static QueueId valueOf(QueueName name, int version){
+        return QueueId.valueOf(name + "_v" + version);
+    }
+
+    public static QueueId valueOf(StringValue value) {
+        return QueueId.valueOf(value.get());
+    }
+
+    public int getVersion(final QueueName queueName) {
+        return Integer.valueOf(get().replaceFirst("^" + queueName.get() + "_v", ""));
+    }
+
+    public static class XmlAdapter extends JaxbStringValueAdapter<QueueId> {
+        @Override
+        protected QueueId createNewInstance(String value) {
+            return QueueId.valueOf(value);
+        }
+    }
+
+    public static class JsonDeserializeAdapater extends JsonDeserializer<QueueId> {
+
+        @Override
+        public QueueId deserialize(
+                final JsonParser jp, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            return QueueId.valueOf(jp.getValueAsString());
+        }
+    }
+
+    public static class JsonSerializeAdapter extends JsonSerializer<QueueId> {
+        @Override
+        public void serialize(
+                final QueueId value, final JsonGenerator jgen, final SerializerProvider provider) throws
+                                                                                                  IOException,
+                                                                                                  JsonProcessingException {
+            jgen.writeString(value.get());
+        }
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
@@ -11,6 +11,7 @@ public enum QueueStatus {
      * New queues are always created in this state
      */
     Provisioning,
+
     Active,
 
     /**

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
@@ -1,5 +1,11 @@
 package io.paradoxical.cassieq.model;
 
+/**
+ * The order of this matters as we will not let
+ * people go down the stack. You can only move forward
+ *
+ * active -> inactive -> deleting
+ */
 public enum QueueStatus {
     Active,
     Deleting,

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
@@ -2,5 +2,6 @@ package io.paradoxical.cassieq.model;
 
 public enum QueueStatus {
     Active,
-    Deleting
+    Deleting,
+    Inactive
 }

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
@@ -7,7 +7,28 @@ package io.paradoxical.cassieq.model;
  * active -> inactive -> deleting
  */
 public enum QueueStatus {
+    /**
+     * New queues are always created in this state
+     */
+    Provisioning,
     Active,
+
+    /**
+     * This is the beginning of being marked for a deletion. You cannot create a new queue
+     * while in this sate
+     */
+    PendingDelete,
+
+    /**
+     * ONce the deletion job tables are populated we can move to this state. You can now
+     * create a queue with the same name if is in this state
+     */
     Deleting,
+
+    /**
+     * Once all deletion jobs are complete (There may be many concurrently),
+     * we set to inactive. This is the only time you can _actually_ remove the queue entry
+     * from the table
+     */
     Inactive
 }

--- a/core/src/main/java/io/paradoxical/cassieq/modules/DefaultApplicationModules.java
+++ b/core/src/main/java/io/paradoxical/cassieq/modules/DefaultApplicationModules.java
@@ -8,6 +8,7 @@ import java.util.List;
 public class DefaultApplicationModules {
     public static List<Module> getModules() {
         return Arrays.asList(
+                new MessageDeletionModule(),
                 new JsonMapperModule(),
                 new DataAccessModule(),
                 new SessionProviderModule(),

--- a/core/src/main/java/io/paradoxical/cassieq/modules/MessageDeletionModule.java
+++ b/core/src/main/java/io/paradoxical/cassieq/modules/MessageDeletionModule.java
@@ -1,0 +1,18 @@
+package io.paradoxical.cassieq.modules;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import io.paradoxical.cassieq.dataAccess.MessageDeletorJobProcessorImpl;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeletorJobProcessor;
+import io.paradoxical.cassieq.factories.MessageDeleterJobProcessorFactory;
+
+public class MessageDeletionModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        install(new FactoryModuleBuilder()
+                        .implement(MessageDeletorJobProcessor.class, MessageDeletorJobProcessorImpl.class)
+                        .build(MessageDeleterJobProcessorFactory.class));
+
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/BaseQueueResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/BaseQueueResource.java
@@ -38,7 +38,7 @@ public abstract class BaseQueueResource {
     }
 
     protected Optional<QueueDefinition> getQueueDefinition(final QueueName queueName) {
-        return queueRepository.getQueue(queueName);
+        return queueRepository.getActiveQueue(queueName);
     }
 
     protected Response buildQueueNotFoundResponse(final QueueName queue) {

--- a/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/QueueDebugResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/QueueDebugResource.java
@@ -203,7 +203,7 @@ public class QueueDebugResource extends BaseQueueResource {
             return buildQueueNotFoundResponse(queueName);
         }
 
-        final MonotonicRepository monotonicRepository = getMonotonicRepoFactory().forQueue(queueDefinition.get());
+        final MonotonicRepository monotonicRepository = getMonotonicRepoFactory().forQueue(queueDefinition.get().getId());
 
         return Response.ok(monotonicRepository.getCurrent())
                        .status(Response.Status.OK)

--- a/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/QueueDebugResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/QueueDebugResource.java
@@ -63,7 +63,7 @@ public class QueueDebugResource extends BaseQueueResource {
     })
     public Response getQueues() {
 
-        final List<QueueDefinition> queues = getQueueRepository().getQueues();
+        final List<QueueDefinition> queues = getQueueRepository().getActiveQueues();
 
         return Response.ok(queues)
                        .status(Response.Status.OK)
@@ -203,7 +203,7 @@ public class QueueDebugResource extends BaseQueueResource {
             return buildQueueNotFoundResponse(queueName);
         }
 
-        final MonotonicRepository monotonicRepository = getMonotonicRepoFactory().forQueue(queueName);
+        final MonotonicRepository monotonicRepository = getMonotonicRepoFactory().forQueue(queueDefinition.get());
 
         return Response.ok(monotonicRepository.getCurrent())
                        .status(Response.Status.OK)

--- a/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/QueueResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/QueueResource.java
@@ -8,6 +8,7 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
 import io.paradoxical.cassieq.dataAccess.exceptions.ExistingMonotonFoundException;
+import io.paradoxical.cassieq.dataAccess.exceptions.QueueAlreadyDeletingException;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.MessageRepoFactory;
 import io.paradoxical.cassieq.factories.MonotonicRepoFactory;
@@ -111,7 +112,13 @@ public class QueueResource extends BaseQueueResource {
             @ApiResponse(code = 500, message = "Server Error")
     })
     public Response deleteQueue(@PathParam("queueName") QueueName queueName) {
-        queueDeleter.delete(queueName);
+        try {
+            queueDeleter.delete(queueName);
+        }
+        catch (QueueAlreadyDeletingException e) {
+            logger.error(e, "Error");
+            return buildErrorResponse("DeleteQueue", queueName, e);
+        }
 
         return Response.ok().build();
     }

--- a/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/QueueResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/resources/api/v1/QueueResource.java
@@ -24,6 +24,7 @@ import io.paradoxical.cassieq.model.QueueStatus;
 import io.paradoxical.cassieq.workers.QueueDeleter;
 import io.paradoxical.cassieq.workers.repair.RepairWorkerManager;
 import lombok.Data;
+import org.apache.commons.lang3.NotImplementedException;
 import org.joda.time.Duration;
 
 import javax.validation.Valid;
@@ -103,8 +104,21 @@ public class QueueResource extends BaseQueueResource {
     }
 
     @DELETE
+    @Path("/")
+    @ApiOperation(value = "Purge inactive queues")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK"),
+            @ApiResponse(code = 204, message = "No message"),
+            @ApiResponse(code = 404, message = "Queue doesn't exist"),
+            @ApiResponse(code = 500, message = "Server Error")
+    })
+    public Response purgeInactive() {
+        throw new NotImplementedException("Purge inactive");
+    }
+
+    @DELETE
     @Path("/{queueName}")
-    @ApiOperation(value = "Get Message")
+    @ApiOperation(value = "Delete queue")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 204, message = "No message"),
@@ -158,7 +172,7 @@ public class QueueResource extends BaseQueueResource {
 
         final Message messageInstance = messageOptional.get();
 
-        final String popReceipt = PopReceipt.from(messageInstance, queueDefinition.get().getId()).toString();
+        final String popReceipt = PopReceipt.from(messageInstance).toString();
 
         final String message = messageInstance.getBlob();
         final GetMessageResponse response = new GetMessageResponse(
@@ -228,14 +242,6 @@ public class QueueResource extends BaseQueueResource {
         }
 
         final PopReceipt popReceipt = PopReceipt.valueOf(popReceiptRaw);
-
-        if (!queueDefinition.get().getId().equals(popReceipt.getQueueId())) {
-            logger.with("popReceipt", popReceipt)
-                  .with("queueDefinition", queueDefinition)
-                  .warn("Pop receipt of old queue found");
-
-            return buildQueueNotFoundResponse(queueName);
-        }
 
         boolean messageAcked;
 

--- a/core/src/main/java/io/paradoxical/cassieq/workers/QueueDeleter.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/QueueDeleter.java
@@ -32,7 +32,7 @@ public class QueueDeleter {
 
         final MessagePointer endPointer = dataContext.getMonotonicRepository().getCurrent();
 
-        dataContext.getQueueRepository().setQueueStatus(queueName, QueueStatus.Deleting);
+        dataContext.getQueueRepository().setQueueStatus(queueDefinition.getId(), QueueStatus.Deleting);
 
         dataContext.getMessageRepository().deleteAllMessages(startPointer, endPointer);
 
@@ -41,7 +41,7 @@ public class QueueDeleter {
         dataContext.getPointerRepository().deleteAll();
 
         // actally delete the queue definition
-        dataContext.getQueueRepository().deleteQueueDefinition(queueDefinition.getQueueName());
+        dataContext.getQueueRepository().deleteQueueDefinition(queueDefinition);
 
         repairWorkerManager.refresh();
     }

--- a/core/src/main/java/io/paradoxical/cassieq/workers/QueueDeleter.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/QueueDeleter.java
@@ -4,72 +4,48 @@ import com.google.inject.Inject;
 import io.paradoxical.cassieq.dataAccess.DeletionJob;
 import io.paradoxical.cassieq.dataAccess.exceptions.QueueAlreadyDeletingException;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
-import io.paradoxical.cassieq.factories.DataContext;
-import io.paradoxical.cassieq.factories.DataContextFactory;
-import io.paradoxical.cassieq.model.InvisibilityMessagePointer;
-import io.paradoxical.cassieq.model.MessagePointer;
-import io.paradoxical.cassieq.model.MonotonicIndex;
+import io.paradoxical.cassieq.factories.MessageDeleterJobProcessorFactory;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueName;
-import io.paradoxical.cassieq.model.QueueStatus;
 import io.paradoxical.cassieq.workers.repair.RepairWorkerManager;
 
 import java.util.Optional;
 
 public class QueueDeleter {
-    private final DataContextFactory factory;
     private final QueueRepository queueRepository;
+    private final MessageDeleterJobProcessorFactory messageDeleterJobProcessorFactory;
     private final RepairWorkerManager repairWorkerManager;
 
     @Inject
     public QueueDeleter(
-            DataContextFactory factory,
             QueueRepository queueRepository,
+            MessageDeleterJobProcessorFactory messageDeleterJobProcessorFactory,
             RepairWorkerManager repairWorkerManager) {
-        this.factory = factory;
         this.queueRepository = queueRepository;
+        this.messageDeleterJobProcessorFactory = messageDeleterJobProcessorFactory;
         this.repairWorkerManager = repairWorkerManager;
     }
 
     public void delete(QueueName queueName) throws QueueAlreadyDeletingException {
-        final QueueDefinition queueDefinition = factory.getDefinition(queueName).get();
+        final Optional<QueueDefinition> optionalDefinition = queueRepository.getActiveQueue(queueName);
+
+        if (!optionalDefinition.isPresent()) {
+            return;
+        }
+
+        final QueueDefinition queueDefinition = optionalDefinition.get();
 
         // This should be the first thing. this way the pointers below can't be modified further.
         final Optional<DeletionJob> deletionJob = queueRepository.tryMarkForDeletion(queueDefinition);
 
-        if(!deletionJob.isPresent()) {
+        if (!deletionJob.isPresent()) {
             throw new QueueAlreadyDeletingException(queueDefinition);
         }
 
-        final DataContext dataContext = factory.forQueue(queueDefinition);
+        // delegate actual work to another processor that handles the job
+        // this can be used to spin up deletion jobs after the fact
+        messageDeleterJobProcessorFactory.createDeletionProcessor(deletionJob.get()).start();
 
-        final MessagePointer startPointer = getMinStartPointer(dataContext, queueDefinition);
-
-        final MessagePointer endPointer = dataContext.getMonotonicRepository().getCurrent();
-
-        dataContext.getMessageRepository().deleteAllMessages(startPointer, endPointer);
-
-        dataContext.getMonotonicRepository().deleteAll();
-
-        dataContext.getPointerRepository().deleteAll();
-
-        // queue definition is now totally inactive
-        queueRepository.tryAdvanceQueueStatus(queueName, QueueStatus.Inactive);
-
-        queueRepository.deleteCompletionJob(deletionJob.get());
-
-        repairWorkerManager.refresh();
-    }
-
-    private MessagePointer getMinStartPointer(DataContext dataContext, QueueDefinition queueDefinition) {
-        final MonotonicIndex repairPointer = dataContext.getPointerRepository().getRepairCurrentBucketPointer().startOf(queueDefinition.getBucketSize());
-
-        final InvisibilityMessagePointer currentInvisPointer = dataContext.getPointerRepository().getCurrentInvisPointer();
-
-        if (repairPointer.get() < currentInvisPointer.get()) {
-            return repairPointer;
-        }
-
-        return currentInvisPointer;
+        repairWorkerManager.notifyChanges();
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/workers/QueueDeleter.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/QueueDeleter.java
@@ -41,7 +41,7 @@ public class QueueDeleter {
         dataContext.getPointerRepository().deleteAll();
 
         // actally delete the queue definition
-        dataContext.getQueueRepository().deleteQueueDefinition(queueDefinition);
+        dataContext.getQueueRepository().tryDeleteQueueDefinition(queueDefinition);
 
         repairWorkerManager.refresh();
     }

--- a/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
@@ -119,7 +119,7 @@ public class ReaderImpl implements Reader {
     }
 
     private Optional<QueueStatus> getQueueStatus() {
-        return dataContext.getQueueRepository().getQueue(queueDefinition.getQueueName()).map(QueueDefinition::getStatus);
+        return dataContext.getQueueRepository().getQueue(queueDefinition.getId()).map(QueueDefinition::getStatus);
     }
 
     @Override

--- a/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
@@ -3,6 +3,7 @@ package io.paradoxical.cassieq.workers.reader;
 import com.godaddy.logging.Logger;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.model.*;
@@ -81,14 +82,17 @@ public class ReaderImpl implements Reader {
     private static final Logger logger = getLogger(ReaderImpl.class);
 
     private final DataContext dataContext;
+    private final QueueRepository queueRepository;
     private final Clock clock;
     private final QueueDefinition queueDefinition;
 
     @Inject
     public ReaderImpl(
             DataContextFactory dataContextFactory,
+            QueueRepository queueRepository,
             Clock clock,
             @Assisted QueueDefinition queueDefinition) {
+        this.queueRepository = queueRepository;
         this.clock = clock;
         this.queueDefinition = queueDefinition;
         dataContext = dataContextFactory.forQueue(queueDefinition);
@@ -119,7 +123,7 @@ public class ReaderImpl implements Reader {
     }
 
     private Optional<QueueStatus> getQueueStatus() {
-        return dataContext.getQueueRepository().getQueue(queueDefinition.getId()).map(QueueDefinition::getStatus);
+        return queueRepository.getQueue(queueDefinition.getId()).map(QueueDefinition::getStatus);
     }
 
     @Override

--- a/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
@@ -6,7 +6,15 @@ import com.google.inject.assistedinject.Assisted;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
-import io.paradoxical.cassieq.model.*;
+import io.paradoxical.cassieq.model.BucketPointer;
+import io.paradoxical.cassieq.model.Clock;
+import io.paradoxical.cassieq.model.InvisibilityMessagePointer;
+import io.paradoxical.cassieq.model.Message;
+import io.paradoxical.cassieq.model.MessagePointer;
+import io.paradoxical.cassieq.model.MonotonicIndex;
+import io.paradoxical.cassieq.model.PopReceipt;
+import io.paradoxical.cassieq.model.QueueDefinition;
+import io.paradoxical.cassieq.model.ReaderBucketPointer;
 import org.joda.time.Duration;
 
 import java.util.List;
@@ -100,7 +108,7 @@ public class ReaderImpl implements Reader {
 
     @Override
     public Optional<Message> nextMessage(Duration invisibility) {
-        if (getQueueStatus().orElse(null) != QueueStatus.Active) {
+        if (!isActive()) {
             return Optional.empty();
         }
 
@@ -122,8 +130,8 @@ public class ReaderImpl implements Reader {
         return nextMessage;
     }
 
-    private Optional<QueueStatus> getQueueStatus() {
-        return queueRepository.getQueue(queueDefinition.getQueueName()).map(QueueDefinition::getStatus);
+    private boolean isActive() {
+        return queueRepository.getActiveQueue(queueDefinition.getQueueName()).isPresent();
     }
 
     @Override

--- a/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
@@ -123,7 +123,7 @@ public class ReaderImpl implements Reader {
     }
 
     private Optional<QueueStatus> getQueueStatus() {
-        return queueRepository.getQueue(queueDefinition.getId()).map(QueueDefinition::getStatus);
+        return queueRepository.getQueue(queueDefinition.getQueueName()).map(QueueDefinition::getStatus);
     }
 
     @Override

--- a/core/src/main/java/io/paradoxical/cassieq/workers/repair/RepairWorkerKey.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/repair/RepairWorkerKey.java
@@ -1,0 +1,37 @@
+package io.paradoxical.cassieq.workers.repair;
+
+import io.paradoxical.cassieq.model.QueueDefinition;
+import lombok.Data;
+
+@Data
+/**
+ * Key that stores the worker and definition
+ * but is hashable and identified by the definition
+ */
+class RepairWorkerKey {
+    private QueueDefinition getQueueDefinition() {
+        return repairWorker.forDefinition();
+    }
+
+    private final RepairWorker repairWorker;
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RepairWorkerKey)) {
+            return false;
+        }
+
+        final RepairWorkerKey that = (RepairWorkerKey) o;
+
+        return !(getQueueDefinition() != null ? !getQueueDefinition().equals(that.getQueueDefinition()) : that.getQueueDefinition() != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return getQueueDefinition() != null ? getQueueDefinition().hashCode() : 0;
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/workers/repair/RepairWorkerManager.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/repair/RepairWorkerManager.java
@@ -5,7 +5,7 @@ public interface RepairWorkerManager {
 
     void stop();
 
-    default void refresh() {
+    default void notifyChanges() {
         start();
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/workers/repair/SimpleRepairWorkerManager.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/repair/SimpleRepairWorkerManager.java
@@ -1,5 +1,6 @@
 package io.paradoxical.cassieq.workers.repair;
 
+import com.godaddy.logging.Logger;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -12,9 +13,12 @@ import org.apache.commons.collections4.CollectionUtils;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.godaddy.logging.LoggerFactory.getLogger;
 import static java.util.stream.Collectors.toSet;
 
 public class SimpleRepairWorkerManager implements RepairWorkerManager {
+    private static final Logger logger = getLogger(SimpleRepairWorkerManager.class);
+
     private final RepairWorkerFactory repairWorkerFactory;
     private final Provider<QueueRepository> queueRepositoryProvider;
     @Getter
@@ -39,6 +43,9 @@ public class SimpleRepairWorkerManager implements RepairWorkerManager {
         final ImmutableSet<RepairWorkerKey> newWorkers = Sets.difference(expectedWorkers, currentRepairWorkers).immutableCopy();
 
         final ImmutableSet<RepairWorkerKey> itemsToStop = Sets.difference(currentRepairWorkers, expectedWorkers).immutableCopy();
+
+        logger.with("count", itemsToStop.size()).info("Removing workers");
+        logger.with("count", newWorkers.size()).info("Workers to add");
 
         itemsToStop.forEach(this::stop);
 

--- a/core/src/main/java/io/paradoxical/cassieq/workers/repair/SimpleRepairWorkerManager.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/repair/SimpleRepairWorkerManager.java
@@ -6,8 +6,6 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.RepairWorkerFactory;
-import io.paradoxical.cassieq.model.QueueDefinition;
-import lombok.Data;
 import lombok.Getter;
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -15,35 +13,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
-
-@Data
-class RepairWorkerKey {
-    private QueueDefinition getQueueDefinition() {
-        return repairWorker.forDefinition();
-    }
-
-    private final RepairWorker repairWorker;
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof RepairWorkerKey)) {
-            return false;
-        }
-
-        final RepairWorkerKey that = (RepairWorkerKey) o;
-
-        return !(getQueueDefinition() != null ? !getQueueDefinition().equals(that.getQueueDefinition()) : that.getQueueDefinition() != null);
-
-    }
-
-    @Override
-    public int hashCode() {
-        return getQueueDefinition() != null ? getQueueDefinition().hashCode() : 0;
-    }
-}
 
 public class SimpleRepairWorkerManager implements RepairWorkerManager {
     private final RepairWorkerFactory repairWorkerFactory;
@@ -61,7 +30,7 @@ public class SimpleRepairWorkerManager implements RepairWorkerManager {
     public synchronized void start() {
         final Set<RepairWorkerKey> expectedWorkers =
                 queueRepositoryProvider.get()
-                                       .getQueues()
+                                       .getActiveQueues()
                                        .stream()
                                        .map(repairWorkerFactory::forQueue)
                                        .map(RepairWorkerKey::new)

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ApiTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ApiTester.java
@@ -55,7 +55,7 @@ public class ApiTester extends TestBase {
 
     @Test
     public void test_client_can_create_put_and_ack() throws Exception {
-        final QueueName queueName = QueueName.valueOf("test");
+        final QueueName queueName = QueueName.valueOf("test_client_can_create_put_and_ack");
 
         client.createQueue(new QueueCreateOptions(queueName)).execute();
 
@@ -80,7 +80,7 @@ public class ApiTester extends TestBase {
 
     @Test
     public void demo_invis_client() throws Exception {
-        final QueueName queueName = QueueName.valueOf("test");
+        final QueueName queueName = QueueName.valueOf("demo_invis_client");
 
         client.createQueue(new QueueCreateOptions(queueName)).execute();
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/MessageRepositoryTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/MessageRepositoryTester.java
@@ -1,8 +1,11 @@
 package io.paradoxical.cassieq.unittests;
 
 import com.google.inject.Injector;
+import io.paradoxical.cassieq.dataAccess.DeletionJob;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeletorJobProcessor;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
+import io.paradoxical.cassieq.factories.MessageDeleterJobProcessorFactory;
 import io.paradoxical.cassieq.model.BucketSize;
 import io.paradoxical.cassieq.model.Message;
 import io.paradoxical.cassieq.model.MonotonicIndex;
@@ -157,7 +160,12 @@ public class MessageRepositoryTester extends TestBase {
 
         assertThat(messages.size()).isEqualTo(1).withFailMessage("Found incorrect number of messages in queue");
 
-        context.getMessageRepository().deleteAllMessages(MonotonicIndex.valueOf(0), context.getMonotonicRepository().getCurrent());
+        final DeletionJob deletionJob = new DeletionJob(queueDefinition);
+
+        final MessageDeletorJobProcessor messageDeletorJobProcessor =
+                defaultInjector.getInstance(MessageDeleterJobProcessorFactory.class).createDeletionProcessor(deletionJob);
+
+        messageDeletorJobProcessor.start();
 
         assertThat(context.getMessageRepository().getMessages(() -> 0L).size()).isEqualTo(0).withFailMessage("Values still existed in queue");
     }

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/PopReceiptTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/PopReceiptTester.java
@@ -3,7 +3,6 @@ package io.paradoxical.cassieq.unittests;
 import io.paradoxical.cassieq.model.Message;
 import io.paradoxical.cassieq.model.MonotonicIndex;
 import io.paradoxical.cassieq.model.PopReceipt;
-import io.paradoxical.cassieq.model.QueueId;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,9 +15,7 @@ public class PopReceiptTester {
 
         Message m = Message.builder().index(monotonicIndex).version(version).build();
 
-        final QueueId queueId = QueueId.valueOf("test");
-
-        final PopReceipt popReceipt = PopReceipt.from(m, queueId);
+        final PopReceipt popReceipt = PopReceipt.from(m);
 
         System.out.println(popReceipt);
 
@@ -26,6 +23,5 @@ public class PopReceiptTester {
 
         assertThat(components.getMessageIndex()).isEqualTo(monotonicIndex);
         assertThat(components.getMessageVersion()).isEqualTo(version);
-        assertThat(components.getQueueId()).isEqualTo(queueId);
     }
 }

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/PopReceiptTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/PopReceiptTester.java
@@ -3,6 +3,7 @@ package io.paradoxical.cassieq.unittests;
 import io.paradoxical.cassieq.model.Message;
 import io.paradoxical.cassieq.model.MonotonicIndex;
 import io.paradoxical.cassieq.model.PopReceipt;
+import io.paradoxical.cassieq.model.QueueId;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +16,9 @@ public class PopReceiptTester {
 
         Message m = Message.builder().index(monotonicIndex).version(version).build();
 
-        final PopReceipt popReceipt = PopReceipt.from(m);
+        final QueueId queueId = QueueId.valueOf("test");
+
+        final PopReceipt popReceipt = PopReceipt.from(m, queueId);
 
         System.out.println(popReceipt);
 
@@ -23,5 +26,6 @@ public class PopReceiptTester {
 
         assertThat(components.getMessageIndex()).isEqualTo(monotonicIndex);
         assertThat(components.getMessageVersion()).isEqualTo(version);
+        assertThat(components.getQueueId()).isEqualTo(queueId);
     }
 }

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/QueueDeleterTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/QueueDeleterTests.java
@@ -1,6 +1,6 @@
 package io.paradoxical.cassieq.unittests;
 
-import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
+import io.paradoxical.cassieq.dataAccess.exceptions.QueueAlreadyDeletingException;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueueDeleterTests extends TestBase {
     @Test
-    public void test_deleter_cleans_up_pointers() throws QueueExistsError {
+    public void test_deleter_cleans_up_pointers() throws QueueAlreadyDeletingException {
         final QueueDeleter deleter = getDefaultInjector().getInstance(QueueDeleter.class);
 
         final QueueRepository instance = getDefaultInjector().getInstance(QueueRepository.class);

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/QueueDeleterTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/QueueDeleterTests.java
@@ -1,5 +1,6 @@
 package io.paradoxical.cassieq.unittests;
 
+import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
@@ -15,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueueDeleterTests extends TestBase {
     @Test
-    public void test_deleter_cleans_up_pointers() {
+    public void test_deleter_cleans_up_pointers() throws QueueExistsError {
         final QueueDeleter deleter = getDefaultInjector().getInstance(QueueDeleter.class);
 
         final QueueRepository instance = getDefaultInjector().getInstance(QueueRepository.class);

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/QueueRepositoryTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/QueueRepositoryTester.java
@@ -5,6 +5,7 @@ import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueName;
+import io.paradoxical.cassieq.model.QueueStatus;
 import org.junit.Test;
 
 import java.util.stream.IntStream;
@@ -58,6 +59,27 @@ public class QueueRepositoryTester extends TestBase {
         }
 
         fail("Queue exists error not thrown");
+    }
+
+    @Test
+    public void queue_defintion_once_in_status_cant_move_backwards() throws QueueExistsError {
+        final Injector defaultInjector = getDefaultInjector();
+
+        final QueueRepository repo = defaultInjector.getInstance(QueueRepository.class);
+
+        final QueueName queueName = QueueName.valueOf("queue_defintion_once_in_status_cant_move_backwards");
+
+        final QueueDefinition queueDefinition = QueueDefinition.builder().queueName(queueName).build();
+
+        repo.createQueue(queueDefinition);
+
+        assertThat(repo.queueExists(queueName)).isEqualTo(true);
+
+        assertThat(repo.trySetQueueDefinitionStatus(queueDefinition.getId(), QueueStatus.Deleting)).isTrue();
+
+        assertThat(repo.trySetQueueDefinitionStatus(queueDefinition.getId(), QueueStatus.Inactive)).isTrue();
+
+        assertThat(repo.trySetQueueDefinitionStatus(queueDefinition.getId(), QueueStatus.Active)).isFalse();
     }
 
     @Test

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/QueueRepositoryTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/QueueRepositoryTester.java
@@ -1,12 +1,14 @@
 package io.paradoxical.cassieq.unittests;
 
+import com.google.inject.Injector;
+import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueName;
-import com.google.inject.Injector;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class QueueRepositoryTester extends TestBase {
     @Test
@@ -29,7 +31,35 @@ public class QueueRepositoryTester extends TestBase {
     }
 
     @Test
-    public void delete_queue(){
+    public void cannot_create_same_queue_twice() throws Exception {
+        final Injector defaultInjector = getDefaultInjector();
+
+        final QueueRepository repo = defaultInjector.getInstance(QueueRepository.class);
+
+        final QueueName queueName = QueueName.valueOf("cannot_create_same_queue_twice");
+
+        assertThat(repo.queueExists(queueName)).isEqualTo(false);
+
+        final QueueDefinition queueDefinition = QueueDefinition.builder().queueName(queueName).build();
+
+        repo.createQueue(queueDefinition);
+
+        assertThat(repo.queueExists(queueName)).isEqualTo(true);
+
+        assertThat(repo.getQueueNames()).contains(queueName);
+
+        try {
+            repo.createQueue(queueDefinition);
+        }
+        catch (QueueExistsError ex) {
+            return;
+        }
+
+        fail("Queue exists error not thrown");
+    }
+
+    @Test
+    public void delete_queue() throws QueueExistsError {
         final Injector defaultInjector = getDefaultInjector();
 
         final QueueRepository repo = defaultInjector.getInstance(QueueRepository.class);
@@ -44,7 +74,7 @@ public class QueueRepositoryTester extends TestBase {
 
         assertThat(repo.getQueueNames()).contains(queueName);
 
-        repo.deleteQueueDefinition(queueName);
+        repo.deleteQueueDefinition(queueDefinition);
 
         assertThat(repo.queueExists(queueName)).isEqualTo(false);
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/QueueRepositoryTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/QueueRepositoryTester.java
@@ -83,6 +83,26 @@ public class QueueRepositoryTester extends TestBase {
     }
 
     @Test
+    public void can_create_new_queue_while_old_queue_is_deleting() throws QueueExistsError {
+        final Injector defaultInjector = getDefaultInjector();
+
+        final QueueRepository repo = defaultInjector.getInstance(QueueRepository.class);
+
+        final QueueName queueName = QueueName.valueOf("delete_queue");
+
+        final QueueDefinition queueDefinition = QueueDefinition.builder().queueName(queueName).build();
+
+        repo.createQueue(queueDefinition);
+
+        assertThat(repo.queueExists(queueName)).isEqualTo(true);
+
+        repo.markForDeletion(queueDefinition);
+
+        // should be able to create a new defintion here
+        repo.createQueue(queueDefinition);
+    }
+
+    @Test
     public void delete_queue() throws QueueExistsError {
         final Injector defaultInjector = getDefaultInjector();
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
@@ -105,7 +105,7 @@ public class ReaderTester extends TestBase {
 
         getTestClock().tick();
 
-        getQueueRepository().markForDeletion(testContext.queueDefinition);
+        getQueueRepository().tryMarkForDeletion(testContext.queueDefinition);
 
         Optional<Message> message = testContext.getReader().nextMessage(Duration.standardSeconds(10));
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
@@ -1,6 +1,7 @@
 package io.paradoxical.cassieq.unittests;
 
 import com.google.inject.Injector;
+import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.factories.ReaderFactory;
@@ -104,7 +105,7 @@ public class ReaderTester extends TestBase {
 
         getTestClock().tick();
 
-        getDataContext(testContext).getQueueRepository().setQueueStatus(testContext.queueDefinition.getId(), QueueStatus.Deleting);
+        getQueueRepository().markForDeletion(testContext.queueDefinition);
 
         Optional<Message> message = testContext.getReader().nextMessage(Duration.standardSeconds(10));
 
@@ -180,10 +181,6 @@ public class ReaderTester extends TestBase {
         return setupTestContext(queueName, 20);
     }
 
-    private DataContext getDataContext(ReaderQueueContext readerQueueContext){
-        return defaultInjector.getInstance(DataContextFactory.class).forQueue(readerQueueContext.getQueueDefinition());
-    }
-
     private ReaderQueueContext setupTestContext(String queueName, int bucketSize) {
         final QueueName queue = QueueName.valueOf(queueName);
         final QueueDefinition queueDefinition = QueueDefinition.builder()
@@ -197,5 +194,9 @@ public class ReaderTester extends TestBase {
         final Reader reader = readerFactory.forQueue(queueDefinition);
 
         return new ReaderQueueContext(queue, queueDefinition, reader);
+    }
+
+    private QueueRepository getQueueRepository() {
+        return getDefaultInjector().getInstance(QueueRepository.class);
     }
 }

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
@@ -64,7 +64,7 @@ public class ReaderTester extends TestBase {
 
             assertThat(message.get().getBlob().equals(blob));
 
-            final PopReceipt popReceipt = PopReceipt.from(message.get(), queueDefinition.getId());
+            final PopReceipt popReceipt = PopReceipt.from(message.get());
 
             return reader.ackMessage(popReceipt);
         }

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
@@ -63,7 +63,7 @@ public class ReaderTester extends TestBase {
 
             assertThat(message.get().getBlob().equals(blob));
 
-            final PopReceipt popReceipt = PopReceipt.from(message.get());
+            final PopReceipt popReceipt = PopReceipt.from(message.get(), queueDefinition.getId());
 
             return reader.ackMessage(popReceipt);
         }
@@ -104,7 +104,7 @@ public class ReaderTester extends TestBase {
 
         getTestClock().tick();
 
-        getDataContext(testContext).getQueueRepository().setQueueStatus(testContext.queueDefinition.getQueueName(), QueueStatus.Deleting);
+        getDataContext(testContext).getQueueRepository().setQueueStatus(testContext.queueDefinition.getId(), QueueStatus.Deleting);
 
         Optional<Message> message = testContext.getReader().nextMessage(Duration.standardSeconds(10));
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
@@ -169,20 +169,44 @@ public class RepairTests extends TestBase {
 
         final RepairWorkerManager manager = defaultInjector.getInstance(RepairWorkerManager.class);
 
-        final QueueName queueName = QueueName.valueOf("repairer_moves_off_ghost_messages");
+        final QueueName queueName = QueueName.valueOf("repair_manager_adds_new_workers");
 
         final QueueDefinition queueDefinition = setupQueue(queueName, 2);
 
         final QueueRepository contextFactory = defaultInjector.getInstance(QueueRepository.class);
 
-        contextFactory.createQueue(queueDefinition);
-
         manager.refresh();
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(1);
 
-        contextFactory.deleteQueueDefinition(queueName);
+        contextFactory.deleteQueueDefinition(queueDefinition);
 
+        manager.refresh();
+
+        assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void repair_manager_properly_keeps_track_of_existing_workers() throws Exception {
+        final Injector defaultInjector = getDefaultInjector(new ServiceConfiguration(), CqlDb.createFresh());
+
+        final RepairWorkerManager manager = defaultInjector.getInstance(RepairWorkerManager.class);
+
+        final QueueName queueName = QueueName.valueOf("repair_manager_properly_keeps_track_of_existing_workers");
+
+        final QueueDefinition queueDefinition = setupQueue(queueName, 2);
+
+        final QueueRepository contextFactory = defaultInjector.getInstance(QueueRepository.class);
+
+        // refreshing twice should not add or remove anyone since no queues were added/deleted
+        manager.refresh();
+        manager.refresh();
+
+        assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(1);
+
+        contextFactory.deleteQueueDefinition(queueDefinition);
+
+        manager.refresh();
         manager.refresh();
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(0);

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
@@ -177,7 +177,7 @@ public class RepairTests extends TestBase {
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(1);
 
-        contextFactory.tryDeleteQueueDefinition(queueDefinition);
+        contextFactory.tryMarkForDeletion(queueDefinition);
 
         manager.refresh();
 
@@ -202,7 +202,7 @@ public class RepairTests extends TestBase {
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(1);
 
-        contextFactory.tryDeleteQueueDefinition(queueDefinition);
+        contextFactory.tryMarkForDeletion(queueDefinition);
 
         manager.refresh();
         manager.refresh();

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
@@ -1,5 +1,6 @@
 package io.paradoxical.cassieq.unittests;
 
+import com.google.inject.Injector;
 import io.paradoxical.cassieq.ServiceConfiguration;
 import io.paradoxical.cassieq.dataAccess.exceptions.ExistingMonotonFoundException;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
@@ -10,13 +11,11 @@ import io.paradoxical.cassieq.model.Message;
 import io.paradoxical.cassieq.model.MessageTag;
 import io.paradoxical.cassieq.model.MonotonicIndex;
 import io.paradoxical.cassieq.model.QueueDefinition;
+import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.ReaderBucketPointer;
 import io.paradoxical.cassieq.model.RepairBucketPointer;
 import io.paradoxical.cassieq.workers.BucketConfiguration;
-import io.paradoxical.cassieq.workers.repair.RepairWorker;
 import io.paradoxical.cassieq.workers.repair.RepairWorkerImpl;
-import io.paradoxical.cassieq.model.QueueName;
-import com.google.inject.Injector;
 import io.paradoxical.cassieq.workers.repair.RepairWorkerManager;
 import io.paradoxical.cassieq.workers.repair.SimpleRepairWorkerManager;
 import org.joda.time.Duration;
@@ -25,7 +24,6 @@ import org.junit.Test;
 import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 public class RepairTests extends TestBase {
     @Test
@@ -122,7 +120,7 @@ public class RepairTests extends TestBase {
                                  .index(index)
                                  .build();
 
-        final RepairWorkerImpl repairWorker = (RepairWorkerImpl)repairWorkerFactory.forQueue(queueDefinition);
+        final RepairWorkerImpl repairWorker = (RepairWorkerImpl) repairWorkerFactory.forQueue(queueDefinition);
 
         RepairBucketPointer repairCurrentBucketPointer = dataContext.getPointerRepository().getRepairCurrentBucketPointer();
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
@@ -173,13 +173,13 @@ public class RepairTests extends TestBase {
 
         final QueueRepository contextFactory = defaultInjector.getInstance(QueueRepository.class);
 
-        manager.refresh();
+        manager.notifyChanges();
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(1);
 
         contextFactory.tryMarkForDeletion(queueDefinition);
 
-        manager.refresh();
+        manager.notifyChanges();
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(0);
     }
@@ -197,15 +197,15 @@ public class RepairTests extends TestBase {
         final QueueRepository contextFactory = defaultInjector.getInstance(QueueRepository.class);
 
         // refreshing twice should not add or remove anyone since no queues were added/deleted
-        manager.refresh();
-        manager.refresh();
+        manager.notifyChanges();
+        manager.notifyChanges();
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(1);
 
         contextFactory.tryMarkForDeletion(queueDefinition);
 
-        manager.refresh();
-        manager.refresh();
+        manager.notifyChanges();
+        manager.notifyChanges();
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(0);
     }

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/RepairTests.java
@@ -177,7 +177,7 @@ public class RepairTests extends TestBase {
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(1);
 
-        contextFactory.deleteQueueDefinition(queueDefinition);
+        contextFactory.tryDeleteQueueDefinition(queueDefinition);
 
         manager.refresh();
 
@@ -202,7 +202,7 @@ public class RepairTests extends TestBase {
 
         assertThat(((SimpleRepairWorkerManager) manager).getCurrentRepairWorkers().size()).isEqualTo(1);
 
-        contextFactory.deleteQueueDefinition(queueDefinition);
+        contextFactory.tryDeleteQueueDefinition(queueDefinition);
 
         manager.refresh();
         manager.refresh();

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/SlowTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/SlowTests.java
@@ -110,7 +110,7 @@ public class SlowTests extends TestBase {
                 final QueueName queueName,
                 final Collection<Integer> collection,
                 final ExecutorService executorService) {
-            super(client, queueName, collection, executorService, null);
+            super(client, queueName, collection, executorService, new TestClock());
         }
 
         @Override

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
@@ -112,7 +112,7 @@ public class TestBase {
 
         queueRepository.createQueue(queueDefinition);
 
-        assertThat(queueRepository.getQueue(queueDefinition.getQueueName()).isPresent()).isTrue();
+        assertThat(queueRepository.getQueueUnsafe(queueDefinition.getQueueName()).isPresent()).isTrue();
     }
 
     protected void createQueue(final QueueDefinition queueDefinition) {

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
@@ -8,7 +8,6 @@ import com.google.inject.Injector;
 import io.dropwizard.logging.BootstrapLogging;
 import io.paradoxical.cassieq.ServiceConfiguration;
 import io.paradoxical.cassieq.configurations.LogMapping;
-import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.model.BucketSize;
 import io.paradoxical.cassieq.model.QueueDefinition;

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
@@ -9,6 +9,7 @@ import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.logging.LoggingFactory;
 import io.paradoxical.cassieq.ServiceConfiguration;
 import io.paradoxical.cassieq.configurations.LogMapping;
+import io.paradoxical.cassieq.dataAccess.exceptions.QueueExistsError;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.model.BucketSize;
 import io.paradoxical.cassieq.model.QueueDefinition;
@@ -109,9 +110,16 @@ public class TestBase {
     private void createQueue(final QueueDefinition queueDefinition, final Injector injector) {
         final QueueRepository queueRepository = injector.getInstance(QueueRepository.class);
 
-        queueRepository.createQueue(queueDefinition);
+        try {
+            queueRepository.createQueue(queueDefinition);
+        }
+        catch (QueueExistsError queueExistsError) {
+            logger.error(queueExistsError, "Error creating queue because it already exists");
 
-        queueRepository.getQueue(queueDefinition.getQueueName()).get();
+            throw new RuntimeException(queueExistsError);
+        }
+
+        queueRepository.getQueue(queueDefinition.getId()).get();
     }
 
     protected void createQueue(final QueueDefinition queueDefinition) {

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBase {
     private static final Logger logger = getLogger(TestBase.class);
@@ -110,16 +111,9 @@ public class TestBase {
     private void createQueue(final QueueDefinition queueDefinition, final Injector injector) {
         final QueueRepository queueRepository = injector.getInstance(QueueRepository.class);
 
-        try {
-            queueRepository.createQueue(queueDefinition);
-        }
-        catch (QueueExistsError queueExistsError) {
-            logger.error(queueExistsError, "Error creating queue because it already exists");
+        queueRepository.createQueue(queueDefinition);
 
-            throw new RuntimeException(queueExistsError);
-        }
-
-        queueRepository.getQueue(queueDefinition.getId()).get();
+        assertThat(queueRepository.getQueue(queueDefinition.getQueueName()).isPresent()).isTrue();
     }
 
     protected void createQueue(final QueueDefinition queueDefinition) {

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -3,7 +3,7 @@ CREATE TABLE queue (
   queuename text,
   bucket_size int,
   max_delivery_count int,
-  status text,
+  status int,
   version int
 );
 
@@ -20,10 +20,10 @@ CREATE TABLE monoton (
   value bigint
 );
 
-CREATE TABLE queue_name_idx(
+CREATE TABLE queue_name_manager(
     queuename text PRIMARY KEY,
     version int,
-    status text
+    status int
 );
 
 CREATE TABLE message (

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -11,7 +11,7 @@ CREATE TABLE pointer (
   pointer_type text,
   value bigint,
 
-  PRIMARY KEY (queueid, pointer_type)
+  PRIMARY KEY (queuename, pointer_type)
 );
 
 CREATE TABLE monoton (

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -1,25 +1,32 @@
 CREATE TABLE queue (
-  queuename text PRIMARY KEY,
+  queueid text PRIMARY KEY,
+  queuename text,
   bucket_size int,
-  max_dequeue_count int,
+  max_delivery_count int,
   status text
 );
 
 CREATE TABLE pointer (
-  queuename text,
+  queueid text,
   pointer_type text,
   value bigint,
 
-  PRIMARY KEY (queuename, pointer_type)
+  PRIMARY KEY (queueid, pointer_type)
 );
 
 CREATE TABLE monoton (
-  queuename text PRIMARY KEY,
+  queueid text PRIMARY KEY,
   value bigint
 );
 
+CREATE TABLE queue_name_idx(
+    queuename text,
+    version int,
+    PRIMARY KEY (queuename, version)
+) WITH CLUSTERING ORDER BY (version DESC);
+
 CREATE TABLE message (
-  queuename text,
+  queueid text,
   bucket_num bigint,
   monoton bigint,
   message text,
@@ -30,5 +37,5 @@ CREATE TABLE message (
   delivery_count int,
   tag text,
 
-  PRIMARY KEY ((queuename, bucket_num), monoton)
+  PRIMARY KEY ((queueid, bucket_num), monoton)
 );

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -19,12 +19,6 @@ CREATE TABLE monoton (
   value bigint
 );
 
-CREATE TABLE queue_name_manager(
-    queuename text PRIMARY KEY,
-    version int,
-    status int
-);
-
 CREATE TABLE message (
   queueid text,
   bucket_num bigint,

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -19,6 +19,13 @@ CREATE TABLE monoton (
   value bigint
 );
 
+CREATE TABLE deletion_job (
+    queuename text,
+    version int,
+    bucket_size int,
+    PRIMARY KEY (queuename, version)
+);
+
 CREATE TABLE message (
   queueid text,
   bucket_num bigint,

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -1,6 +1,5 @@
 CREATE TABLE queue (
-  queueid text PRIMARY KEY,
-  queuename text,
+  queuename text PRIMARY KEY,
   bucket_size int,
   max_delivery_count int,
   status int,
@@ -8,7 +7,7 @@ CREATE TABLE queue (
 );
 
 CREATE TABLE pointer (
-  queueid text,
+  queuename text,
   pointer_type text,
   value bigint,
 
@@ -16,7 +15,7 @@ CREATE TABLE pointer (
 );
 
 CREATE TABLE monoton (
-  queueid text PRIMARY KEY,
+  queuename text PRIMARY KEY,
   value bigint
 );
 

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -7,15 +7,15 @@ CREATE TABLE queue (
 );
 
 CREATE TABLE pointer (
-  queuename text,
+  queueid text,
   pointer_type text,
   value bigint,
 
-  PRIMARY KEY (queuename, pointer_type)
+  PRIMARY KEY (queueid, pointer_type)
 );
 
 CREATE TABLE monoton (
-  queuename text PRIMARY KEY,
+  queueid text PRIMARY KEY,
   value bigint
 );
 

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -3,7 +3,8 @@ CREATE TABLE queue (
   queuename text,
   bucket_size int,
   max_delivery_count int,
-  status text
+  status text,
+  version int
 );
 
 CREATE TABLE pointer (
@@ -20,10 +21,10 @@ CREATE TABLE monoton (
 );
 
 CREATE TABLE queue_name_idx(
-    queuename text,
+    queuename text PRIMARY KEY,
     version int,
-    PRIMARY KEY (queuename, version)
-) WITH CLUSTERING ORDER BY (version DESC);
+    status text
+);
 
 CREATE TABLE message (
   queueid text,

--- a/scripts/start-cassandra.sh
+++ b/scripts/start-cassandra.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+docker stop cassandra
+
+docker rm cassandra
+
+db=/srv/cassandra-db
+
+
+#    -v $db:/var/lib/cassandra \
+
+docker run -d \
+    --name cassandra \
+    -p 9042:9042 \
+    -p 9160:9160 \
+    -e CASSANDRA_CLUSTER_NAME=local \
+    -e CASSANDRA_DC=local \
+    cassandra:2.2.4


### PR DESCRIPTION
Fixing #20 

Queues now have a unique identifier and we allow only 1 active queue of that queuename at a time.

This helps solve issues with deleting a queue where potential ghost messages can be leftover since ti is very hard to delete all messages (without an actual table drop).

We also are set up now for async queue purges since once a queue is marked in the deleting phase we can create a new queue with that name (even though internally its tracked with a `_vN` marker for its queue id).

I also made QueueStatus an ordinal enum in the db, which while it sucks for debugging purposes, is nice cause we can now do atomic state changes.  I've disallowed a queue to move from Inactive/Deleting back to active. The state change is now

```
Active -> Deleting -> Inactive
Active -> InActive
```

And you can't violate this. This will help prevent potential multiple people trying to change the state of a queue definition (even though right now we only support moving to a deleting phase and then we just delete when we are done

Pop receipts were also updated to track their queue id so that someone can't accidentally ack a message on a new version of the same queue name.  A situation _could_ have arisen that you had queue XYZ up to monoton 10, then you deleted it, but an active worker is still out there. You create a new queue called XYZ and put in messages up to monoton 10. Now the old worker comes and acks. Without encoding the unique queue id the old worker can ack the new message which is incorrect, hence the addition of that data.

I also pulled out the QueueRepository from the data context since it was really out of place there.  It wasn't tied to a particular queue but the data context is.  

The PR contains a few other fixes related to the last PR. 

I also made logging less verbose in the tests by setting entire packages to OFF.  
