### PR TITLE
Bugfix/queue deleter could mark queue inactive even if active

### DIFF
--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageDeletorJobProcessorImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageDeletorJobProcessorImpl.java
@@ -6,7 +6,7 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
-import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeletorJobProcessor;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeleterJobProcessor;
 import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
 import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
@@ -28,7 +28,7 @@ import java.util.stream.IntStream;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.in;
 
-public class MessageDeletorJobProcessorImpl implements MessageDeletorJobProcessor {
+public class MessageDeletorJobProcessorImpl implements MessageDeleterJobProcessor {
     private final Session session;
     private final QueueRepository queueRepository;
     private final DeletionJob job;

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/MessageDeleterJobProcessor.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/MessageDeleterJobProcessor.java
@@ -1,5 +1,5 @@
 package io.paradoxical.cassieq.dataAccess.interfaces;
 
-public interface MessageDeletorJobProcessor {
+public interface MessageDeleterJobProcessor {
     void start();
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/QueueRepository.java
@@ -4,6 +4,7 @@ import io.paradoxical.cassieq.dataAccess.DeletionJob;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.QueueStatus;
+import lombok.NonNull;
 
 import java.util.List;
 import java.util.Optional;

--- a/core/src/main/java/io/paradoxical/cassieq/factories/MessageDeleterJobProcessorFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/MessageDeleterJobProcessorFactory.java
@@ -1,8 +1,8 @@
 package io.paradoxical.cassieq.factories;
 
 import io.paradoxical.cassieq.dataAccess.DeletionJob;
-import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeletorJobProcessor;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeleterJobProcessor;
 
 public interface MessageDeleterJobProcessorFactory {
-    MessageDeletorJobProcessor createDeletionProcessor(DeletionJob job);
+    MessageDeleterJobProcessor createDeletionProcessor(DeletionJob job);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueueStatus.java
@@ -2,9 +2,10 @@ package io.paradoxical.cassieq.model;
 
 /**
  * The order of this matters as we will not let
- * people go down the stack. You can only move forward
+ * people go down the stack. You can only move forward (but circularly)
  *
- * active -> inactive -> deleting
+ * This means if you are at deleting you can go to inactive, but if you are inactive
+ * you can't go to deleting
  */
 public enum QueueStatus {
     /**
@@ -19,7 +20,7 @@ public enum QueueStatus {
 
     /**
      * This is the beginning of being marked for a deletion. You cannot create a new queue
-     * while in this sate
+     * while in this state
      */
     PendingDelete,
 
@@ -34,5 +35,5 @@ public enum QueueStatus {
      * we set to inactive. This is the only time you can _actually_ remove the queue entry
      * from the table
      */
-    Inactive
+    Inactive,
 }

--- a/core/src/main/java/io/paradoxical/cassieq/modules/MessageDeletionModule.java
+++ b/core/src/main/java/io/paradoxical/cassieq/modules/MessageDeletionModule.java
@@ -3,7 +3,7 @@ package io.paradoxical.cassieq.modules;
 import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import io.paradoxical.cassieq.dataAccess.MessageDeletorJobProcessorImpl;
-import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeletorJobProcessor;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeleterJobProcessor;
 import io.paradoxical.cassieq.factories.MessageDeleterJobProcessorFactory;
 
 public class MessageDeletionModule extends AbstractModule {
@@ -11,7 +11,7 @@ public class MessageDeletionModule extends AbstractModule {
     @Override
     protected void configure() {
         install(new FactoryModuleBuilder()
-                        .implement(MessageDeletorJobProcessor.class, MessageDeletorJobProcessorImpl.class)
+                        .implement(MessageDeleterJobProcessor.class, MessageDeletorJobProcessorImpl.class)
                         .build(MessageDeleterJobProcessorFactory.class));
 
     }

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/MessageRepositoryTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/MessageRepositoryTester.java
@@ -2,7 +2,7 @@ package io.paradoxical.cassieq.unittests;
 
 import com.google.inject.Injector;
 import io.paradoxical.cassieq.dataAccess.DeletionJob;
-import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeletorJobProcessor;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeleterJobProcessor;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.factories.MessageDeleterJobProcessorFactory;
@@ -162,7 +162,7 @@ public class MessageRepositoryTester extends TestBase {
 
         final DeletionJob deletionJob = new DeletionJob(queueDefinition);
 
-        final MessageDeletorJobProcessor messageDeletorJobProcessor =
+        final MessageDeleterJobProcessor messageDeletorJobProcessor =
                 defaultInjector.getInstance(MessageDeleterJobProcessorFactory.class).createDeletionProcessor(deletionJob);
 
         messageDeletorJobProcessor.start();

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/QueueDeleterTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/QueueDeleterTests.java
@@ -1,20 +1,101 @@
 package io.paradoxical.cassieq.unittests;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.assistedinject.Assisted;
+import io.paradoxical.cassieq.dataAccess.DeletionJob;
+import io.paradoxical.cassieq.dataAccess.MessageDeletorJobProcessorImpl;
 import io.paradoxical.cassieq.dataAccess.exceptions.QueueAlreadyDeletingException;
+import io.paradoxical.cassieq.dataAccess.interfaces.MessageDeleterJobProcessor;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
+import io.paradoxical.cassieq.factories.MessageDeleterJobProcessorFactory;
 import io.paradoxical.cassieq.model.InvisibilityMessagePointer;
 import io.paradoxical.cassieq.model.MonotonicIndex;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.ReaderBucketPointer;
+import io.paradoxical.cassieq.unittests.modules.MessageDeletorJobModule;
 import io.paradoxical.cassieq.workers.QueueDeleter;
 import org.junit.Test;
 
+import java.util.Optional;
+import java.util.concurrent.Semaphore;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class QueueDeleterTests extends TestBase {
+    @Test
+    public void can_create_queue_while_job_is_deleting() throws QueueAlreadyDeletingException, InterruptedException {
+
+        final MessageDeleterJobProcessorFactory jobSpy = spy(MessageDeleterJobProcessorFactory.class);
+
+        final Injector defaultInjector = getDefaultInjector(new MessageDeletorJobModule(jobSpy));
+
+        final Semaphore start = new Semaphore(1);
+
+        final Thread[] deletion = new Thread[1];
+
+        when(jobSpy.createDeletionProcessor(any())).thenAnswer(answer -> {
+            deletion[0] = new Thread(() -> {
+                try {
+                    start.acquire();
+
+                    final MessageDeletorJobProcessorImpl realDeletor = defaultInjector.createChildInjector(new AbstractModule() {
+                        @Override
+                        protected void configure() {
+                            bind(DeletionJob.class)
+                                    .annotatedWith(Assisted.class)
+                                    .toInstance(((DeletionJob) answer.getArguments()[0]));
+                        }
+                    }).getInstance(MessageDeletorJobProcessorImpl.class);
+
+                    realDeletor.start();
+                }
+                catch (Exception e) {
+                    System.out.println(e);
+                }
+            });
+
+            deletion[0].start();
+
+            return mock(MessageDeleterJobProcessor.class);
+        });
+
+
+        final QueueDeleter queueDeleter = defaultInjector.getInstance(QueueDeleter.class);
+
+        final QueueRepository instance = defaultInjector.getInstance(QueueRepository.class);
+
+        final QueueName name = QueueName.valueOf("can_create_queue_while_job_is_deleting");
+
+        final QueueDefinition build = QueueDefinition.builder().queueName(name).build();
+
+        instance.createQueue(build);
+
+        queueDeleter.delete(name);
+
+        // should be able to make new queue
+        final Optional<QueueDefinition> queue = instance.createQueue(build);
+
+        assertThat(queue).isPresent();
+        assertThat(queue.get().getVersion()).isEqualTo(1);
+
+        start.release();
+
+        deletion[0].join();
+
+        final QueueDefinition activeQueue = instance.getActiveQueue(queue.get().getQueueName()).get();
+
+        // make sure the deletor when it completed didn't just kill this active queue
+        assertThat(activeQueue.getVersion()).isEqualTo(queue.get().getVersion());
+    }
+
     @Test
     public void test_deleter_cleans_up_pointers() throws QueueAlreadyDeletingException {
         final QueueDeleter deleter = getDefaultInjector().getInstance(QueueDeleter.class);

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/QueueRepositoryTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/QueueRepositoryTester.java
@@ -69,13 +69,20 @@ public class QueueRepositoryTester extends TestBase {
 
         assertThat(repo.getQueueUnsafe(queueName).isPresent()).isEqualTo(true);
 
-        assertThat(repo.tryAdvanceQueueStatus(queueDefinition.getQueueName(), QueueStatus.Deleting)).isTrue();
+        assertThat(repo.getQueueUnsafe(queueName).get().getStatus()).isEqualTo(QueueStatus.Active);
+
+        // no skipping a state
+        assertThat(repo.tryAdvanceQueueStatus(queueDefinition.getQueueName(), QueueStatus.Inactive)).isFalse();
+
+        assertThat(repo.tryAdvanceQueueStatus(queueDefinition.getQueueName(), QueueStatus.PendingDelete)).isTrue();
 
         // ok to move to the same again
+        assertThat(repo.tryAdvanceQueueStatus(queueDefinition.getQueueName(), QueueStatus.Deleting)).isTrue();
         assertThat(repo.tryAdvanceQueueStatus(queueDefinition.getQueueName(), QueueStatus.Deleting)).isTrue();
 
         assertThat(repo.tryAdvanceQueueStatus(queueDefinition.getQueueName(), QueueStatus.Inactive)).isTrue();
 
+        // can't go backwards
         assertThat(repo.tryAdvanceQueueStatus(queueDefinition.getQueueName(), QueueStatus.Active)).isFalse();
     }
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
@@ -11,7 +11,6 @@ import io.paradoxical.cassieq.model.MonotonicIndex;
 import io.paradoxical.cassieq.model.PopReceipt;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueName;
-import io.paradoxical.cassieq.model.QueueStatus;
 import io.paradoxical.cassieq.unittests.time.TestClock;
 import io.paradoxical.cassieq.workers.reader.Reader;
 import lombok.NonNull;
@@ -31,7 +30,8 @@ public class ReaderTester extends TestBase {
         this.defaultInjector = getDefaultInjector();
     }
 
-    @Value class ReaderQueueContext {
+    @Value
+    class ReaderQueueContext {
 
         @NonNull
         QueueName queueName;

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/TestBase.java
@@ -18,11 +18,14 @@ import io.paradoxical.cassieq.unittests.modules.MockEnvironmentModule;
 import io.paradoxical.cassieq.unittests.modules.TestClockModule;
 import io.paradoxical.cassieq.unittests.time.TestClock;
 import io.paradoxical.common.test.guice.ModuleUtils;
+import io.paradoxical.common.test.guice.OverridableModule;
 import lombok.AccessLevel;
 import lombok.Getter;
+import org.apache.commons.collections4.ListUtils;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,19 +78,34 @@ public class TestBase {
     }
 
     protected Injector getDefaultInjector(ServiceConfiguration configuration) {
-        return getDefaultInjector(configuration, session);
+        return getDefaultInjector(configuration, new OverridableModule[]{});
     }
 
     protected Injector getDefaultInjector(ServiceConfiguration configuration, Session session) {
-        return Governator.createInjector(
-                ModuleUtils.mergeModules(DefaultApplicationModules.getModules(),
-                                         new InMemorySessionProvider(session),
-                                         new MockEnvironmentModule(configuration),
-                                         new TestClockModule(testClock)));
+        return getDefaultInjectorRaw(Arrays.asList(new InMemorySessionProvider(session),
+                                                   new MockEnvironmentModule(configuration),
+                                                   new TestClockModule(testClock)));
     }
 
     protected Injector getDefaultInjector() {
         return getDefaultInjector(new ServiceConfiguration());
+    }
+
+    protected Injector getDefaultInjector(OverridableModule... modules) {
+        return getDefaultInjector(new ServiceConfiguration(), modules);
+    }
+
+    protected Injector getDefaultInjector(final ServiceConfiguration serviceConfiguration, OverridableModule... modules) {
+        return getDefaultInjectorRaw(ListUtils.union(Arrays.asList(modules),
+                                                     Arrays.asList(new InMemorySessionProvider(session),
+                                                                                         new MockEnvironmentModule(serviceConfiguration),
+                                                                                         new TestClockModule(testClock))));
+    }
+
+    private Injector getDefaultInjectorRaw(final List<OverridableModule> overridableModules) {
+        return Governator.createInjector(
+                ModuleUtils.mergeModules(DefaultApplicationModules.getModules(),
+                                         overridableModules));
     }
 
     protected QueueDefinition setupQueue(QueueName queueName) {

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/modules/MessageDeletorJobModule.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/modules/MessageDeletorJobModule.java
@@ -1,0 +1,24 @@
+package io.paradoxical.cassieq.unittests.modules;
+
+import com.google.inject.Module;
+import io.paradoxical.cassieq.factories.MessageDeleterJobProcessorFactory;
+import io.paradoxical.cassieq.modules.MessageDeletionModule;
+import io.paradoxical.common.test.guice.OverridableModule;
+
+public class MessageDeletorJobModule extends OverridableModule {
+    private final MessageDeleterJobProcessorFactory processor;
+
+    public MessageDeletorJobModule(MessageDeleterJobProcessorFactory processor) {
+        this.processor = processor;
+    }
+
+    @Override
+    public Class<? extends Module> getOverridesModule() {
+        return MessageDeletionModule.class;
+    }
+
+    @Override
+    protected void configure() {
+        bind(MessageDeleterJobProcessorFactory.class).toInstance(processor);
+    }
+}


### PR DESCRIPTION
If a deletion job ran async then we would mark a queue as inactive even though it was active. If this happened we'd also end up deleting the queue definition and basically borking someones new queue definition based on an old delete.

I made it so that we MUST enforce state transitions.  

The issue occurred because we were able to create a queue into the `Active` state but then the deleter jumped states and force made it `Inactive`. This was fine with our previous invariant of "moving through states forward" (active < inactive, so it treated as :ok: even though its :-1: )

Now if we enforce "moving through states one by one" then we can avoid this jump. You can't get to inactive without going through a deletion phase, which is what we want.
