### PR TITLE
Feature/cleanup invis code

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,6 +74,7 @@
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-assistedinject</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>

--- a/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
+++ b/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
@@ -25,6 +25,7 @@ import io.paradoxical.cassieq.bundles.GuiceBundleProvider;
 import io.paradoxical.cassieq.serialization.JacksonJsonMapper;
 import io.paradoxical.common.web.web.filter.CorrelationIdFilter;
 import io.paradoxical.common.web.web.filter.JerseyRequestLogging;
+import lombok.Getter;
 import org.joda.time.DateTimeZone;
 
 import java.util.ArrayList;
@@ -37,11 +38,13 @@ import static com.godaddy.logging.LoggerFactory.getLogger;
 public class ServiceApplication extends Application<ServiceConfiguration> {
 
     private static final Logger logger = getLogger(ServiceApplication.class);
+
+    @Getter
     private final GuiceBundleProvider guiceBundleProvider;
+
     private Environment env;
 
     public ServiceApplication(final GuiceBundleProvider guiceBundleProvider) {
-
         this.guiceBundleProvider = guiceBundleProvider;
     }
 
@@ -101,6 +104,7 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
     @Override
     public void run(ServiceConfiguration config, final Environment env) throws Exception {
         this.env = env;
+
         ArrayList<BiConsumer<ServiceConfiguration, Environment>> run = new ArrayList<>();
 
         run.add(this::configureJson);

--- a/core/src/main/java/io/paradoxical/cassieq/bundles/GuiceBundleProvider.java
+++ b/core/src/main/java/io/paradoxical/cassieq/bundles/GuiceBundleProvider.java
@@ -2,13 +2,12 @@ package io.paradoxical.cassieq.bundles;
 
 import com.google.inject.Injector;
 import com.google.inject.Module;
-import com.google.inject.Stage;
 import com.hubspot.dropwizard.guice.GuiceBundle;
-import com.hubspot.dropwizard.guice.InjectorFactory;
 import com.netflix.governator.Governator;
 import io.paradoxical.cassieq.ServiceApplication;
 import io.paradoxical.cassieq.ServiceConfiguration;
 import io.paradoxical.cassieq.modules.DefaultApplicationModules;
+import lombok.Getter;
 
 import java.util.List;
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageRepositoryImpl.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.gte;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 import static com.godaddy.logging.LoggerFactory.getLogger;
 import static java.util.stream.Collectors.toList;

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/PointerRepositoryImpl.java
@@ -75,6 +75,8 @@ public class PointerRepositoryImpl extends RepositoryBase implements PointerRepo
         }
 
         // someone else moved it, get that value
+        moveLogger.info("Other process moved invis pointer, retrieving");
+
         return getCurrentInvisPointer();
     }
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/SpecialIndex.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/SpecialIndex.java
@@ -1,0 +1,16 @@
+package io.paradoxical.cassieq.dataAccess;
+
+import io.paradoxical.cassieq.model.MonotonicIndex;
+import lombok.Getter;
+
+public enum SpecialIndex {
+    Finalizer(MonotonicIndex.valueOf(-3)),
+    Tombstone(MonotonicIndex.valueOf(-2));
+
+    @Getter
+    private final MonotonicIndex index;
+
+    SpecialIndex(final MonotonicIndex monotonicIndex) {
+        index = monotonicIndex;
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/SpecialIndexes.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/SpecialIndexes.java
@@ -1,0 +1,9 @@
+package io.paradoxical.cassieq.dataAccess;
+
+import io.paradoxical.cassieq.model.MonotonicIndex;
+
+public final class SpecialIndexes {
+    public static final MonotonicIndex finalized = MonotonicIndex.valueOf(-3);
+
+    public static final MonotonicIndex tombstone =   MonotonicIndex.valueOf(-2);
+}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/SpecialIndexes.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/SpecialIndexes.java
@@ -1,9 +1,0 @@
-package io.paradoxical.cassieq.dataAccess;
-
-import io.paradoxical.cassieq.model.MonotonicIndex;
-
-public final class SpecialIndexes {
-    public static final MonotonicIndex finalized = MonotonicIndex.valueOf(-3);
-
-    public static final MonotonicIndex tombstone =   MonotonicIndex.valueOf(-2);
-}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tombstone.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tombstone.java
@@ -1,7 +1,0 @@
-package io.paradoxical.cassieq.dataAccess;
-
-import io.paradoxical.cassieq.model.MonotonicIndex;
-
-public final class Tombstone {
-    public static final MonotonicIndex index =   MonotonicIndex.valueOf(-2);
-}

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/MessageRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/MessageRepository.java
@@ -6,6 +6,7 @@ import io.paradoxical.cassieq.model.Message;
 import io.paradoxical.cassieq.model.MessagePointer;
 import io.paradoxical.cassieq.model.MessageUpdateRequest;
 import io.paradoxical.cassieq.model.ReaderBucketPointer;
+import io.paradoxical.cassieq.model.RepairBucketPointer;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
@@ -26,10 +27,12 @@ public interface MessageRepository {
     boolean ackMessage(final Message message);
 
     default List<Message> getMessages(final BucketPointer bucketPointer) {
-        return getBucketContents(bucketPointer).stream().filter(Message::isNotTombstone).collect(toList());
+        return getBucketContents(bucketPointer).stream().filter(Message::isNotSpecial).collect(toList());
     }
 
     List<Message> getBucketContents(final BucketPointer bucketPointer);
+
+    boolean finalize(RepairBucketPointer bucketPointer);
 
     boolean tombstone(final ReaderBucketPointer bucketPointer);
 
@@ -40,4 +43,6 @@ public interface MessageRepository {
     void deleteAllMessages(BucketPointer bucket);
 
     Optional<Message> updateMessage(MessageUpdateRequest message);
+
+    boolean finalizedExists(BucketPointer bucketPointer);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/factories/InvisLocaterFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/InvisLocaterFactory.java
@@ -1,8 +1,8 @@
 package io.paradoxical.cassieq.factories;
 
 import io.paradoxical.cassieq.model.QueueDefinition;
-import io.paradoxical.cassieq.workers.reader.InvisLocatorImpl;
+import io.paradoxical.cassieq.workers.reader.InvisLocator;
 
 public interface InvisLocaterFactory {
-    InvisLocatorImpl forQueue(QueueDefinition definition);
+    InvisLocator forQueue(QueueDefinition definition);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/model/BucketPointer.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/BucketPointer.java
@@ -1,4 +1,11 @@
 package io.paradoxical.cassieq.model;
 
 public interface BucketPointer extends Pointer {
+    default BucketPointer next(){
+        return ReaderBucketPointer.valueOf(get() + 1);
+    }
+
+    default MonotonicIndex startOf(BucketSize bucketsize){
+        return MonotonicIndex.valueOf(get() * bucketsize.get());
+    }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/model/BucketPointer.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/BucketPointer.java
@@ -2,7 +2,7 @@ package io.paradoxical.cassieq.model;
 
 public interface BucketPointer extends Pointer {
     default BucketPointer next(){
-        return ReaderBucketPointer.valueOf(get() + 1);
+        return GenericBucketPointer.valueOf(get() + 1);
     }
 
     default MonotonicIndex startOf(BucketSize bucketsize){

--- a/core/src/main/java/io/paradoxical/cassieq/model/GenericBucketPointer.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/GenericBucketPointer.java
@@ -1,0 +1,58 @@
+package io.paradoxical.cassieq.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.paradoxical.common.valuetypes.LongValue;
+import io.paradoxical.common.valuetypes.adapters.xml.JaxbLongValueAdapter;
+import jdk.nashorn.internal.ir.annotations.Immutable;
+
+import javax.annotation.Nonnull;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.io.IOException;
+
+@Immutable
+@XmlJavaTypeAdapter(value = GenericBucketPointer.XmlAdapter.class)
+@JsonSerialize(using = GenericBucketPointer.JsonSerializeAdapter.class)
+@JsonDeserialize(using = GenericBucketPointer.JsonDeserializeAdapater.class)
+public final class GenericBucketPointer extends LongValue implements BucketPointer {
+    protected GenericBucketPointer(final Long value) {
+        super(value);
+    }
+
+    public static GenericBucketPointer valueOf(long value) {
+        return new GenericBucketPointer(value);
+    }
+
+    public static class XmlAdapter extends JaxbLongValueAdapter<GenericBucketPointer> {
+
+        @Nonnull
+        @Override
+        protected GenericBucketPointer createNewInstance(final Long value) {
+            return GenericBucketPointer.valueOf(value);
+        }
+    }
+
+    public static class JsonDeserializeAdapater extends JsonDeserializer<GenericBucketPointer> {
+
+        @Override
+        public GenericBucketPointer deserialize(final JsonParser jp, final DeserializationContext ctxt)
+                throws IOException {
+            return GenericBucketPointer.valueOf(jp.getValueAsLong());
+        }
+    }
+
+    public static class JsonSerializeAdapter extends JsonSerializer<GenericBucketPointer> {
+        @SuppressWarnings("ConstantConditions")
+        @Override
+        public void serialize(final GenericBucketPointer value, final JsonGenerator jgen, final SerializerProvider provider)
+                throws IOException {
+            jgen.writeNumber(value.get());
+        }
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/model/Message.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/Message.java
@@ -4,7 +4,7 @@ import com.datastax.driver.core.Row;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.godaddy.logging.LoggingScope;
 import com.godaddy.logging.Scope;
-import io.paradoxical.cassieq.dataAccess.SpecialIndexes;
+import io.paradoxical.cassieq.dataAccess.SpecialIndex;
 import io.paradoxical.cassieq.dataAccess.Tables;
 import io.paradoxical.cassieq.model.time.Clock;
 import lombok.Builder;
@@ -37,9 +37,9 @@ public class Message {
         return nextVisiblityAt == null || nextVisiblityAt.isBefore(clock.now()) || nextVisiblityAt.isEqual(clock.now());
     }
 
-    public boolean isTombstone() { return getIndex().equals(SpecialIndexes.tombstone); }
+    public boolean isTombstone() { return getIndex().equals(SpecialIndex.Tombstone.getIndex()); }
 
-    public boolean isFinalized() { return getIndex().equals(SpecialIndexes.finalized); }
+    public boolean isFinalized() { return getIndex().equals(SpecialIndex.Finalizer.getIndex()); }
 
     @JsonIgnore
     public boolean isNotAcked() {

--- a/core/src/main/java/io/paradoxical/cassieq/model/Message.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/Message.java
@@ -46,6 +46,11 @@ public class Message {
     }
 
     @JsonIgnore
+    public boolean isRevived(Clock clock){
+        return isNotAcked() && isVisible(clock) && getDeliveryCount() > 0;
+    }
+
+    @JsonIgnore
     public boolean isNotVisible(Clock clock) {
         return !isVisible(clock);
     }

--- a/core/src/main/java/io/paradoxical/cassieq/model/Message.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/Message.java
@@ -4,13 +4,12 @@ import com.datastax.driver.core.Row;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.godaddy.logging.LoggingScope;
 import com.godaddy.logging.Scope;
+import io.paradoxical.cassieq.dataAccess.SpecialIndexes;
 import io.paradoxical.cassieq.dataAccess.Tables;
-import io.paradoxical.cassieq.dataAccess.Tombstone;
 import io.paradoxical.cassieq.model.time.Clock;
 import lombok.Builder;
 import lombok.Data;
 import org.joda.time.DateTime;
-import org.joda.time.Duration;
 
 @Data
 @Builder
@@ -38,7 +37,9 @@ public class Message {
         return nextVisiblityAt == null || nextVisiblityAt.isBefore(clock.now()) || nextVisiblityAt.isEqual(clock.now());
     }
 
-    public boolean isTombstone() { return getIndex().equals(Tombstone.index); }
+    public boolean isTombstone() { return getIndex().equals(SpecialIndexes.tombstone); }
+
+    public boolean isFinalized() { return getIndex().equals(SpecialIndexes.finalized); }
 
     @JsonIgnore
     public boolean isNotAcked() {
@@ -46,7 +47,7 @@ public class Message {
     }
 
     @JsonIgnore
-    public boolean isRevived(Clock clock){
+    public boolean isRevived(Clock clock) {
         return isNotAcked() && isVisible(clock) && getDeliveryCount() > 0;
     }
 
@@ -56,7 +57,7 @@ public class Message {
     }
 
     @JsonIgnore
-    public boolean isNotTombstone() { return !isTombstone(); }
+    public boolean isNotSpecial() { return !isTombstone() && !isFinalized(); }
 
     public PopReceipt getPopReceipt() {
         return PopReceipt.from(this);

--- a/core/src/main/java/io/paradoxical/cassieq/model/ReaderBucketPointer.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/ReaderBucketPointer.java
@@ -35,10 +35,6 @@ public final class ReaderBucketPointer extends LongValue implements BucketPointe
         return new ReaderBucketPointer(get() + 1);
     }
 
-    public MonotonicIndex startOf(BucketSize bucketsize) {
-        return MonotonicIndex.valueOf(get() * bucketsize.get());
-    }
-
     public static ReaderBucketPointer map(Row row) {
         return ReaderBucketPointer.valueOf(row.getLong(Tables.Pointer.VALUE));
     }

--- a/core/src/main/java/io/paradoxical/cassieq/workers/reader/InvisLocator.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/reader/InvisLocator.java
@@ -1,4 +1,11 @@
 package io.paradoxical.cassieq.workers.reader;
 
+import io.paradoxical.cassieq.model.InvisibilityMessagePointer;
+import io.paradoxical.cassieq.model.Message;
+import org.joda.time.Duration;
+
+import java.util.Optional;
+
 public interface InvisLocator {
+    Optional<Message> tryConsumeNextVisibleMessage(InvisibilityMessagePointer pointer, Duration invisiblity);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/workers/reader/InvisLocatorImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/reader/InvisLocatorImpl.java
@@ -17,6 +17,7 @@ import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.ReaderBucketPointer;
 import io.paradoxical.cassieq.model.time.Clock;
 import lombok.Cleanup;
+import lombok.Data;
 import org.joda.time.Duration;
 
 import java.util.List;
@@ -90,6 +91,26 @@ import static com.godaddy.logging.LoggerFactory.getLogger;
  * 3 *
  */
 
+@Data
+class InvisBucketProcessResult {
+    private final Optional<Message> message;
+
+    private final BucketResult resultAction;
+
+    public static InvisBucketProcessResult nextBucket(){
+        return new InvisBucketProcessResult(Optional.empty(), BucketResult.GoNext);
+    }
+
+    public static InvisBucketProcessResult of(Optional<Message> message){
+        return new InvisBucketProcessResult(message, BucketResult.Stop);
+    }
+}
+
+enum BucketResult {
+    GoNext,
+    Stop
+}
+
 public class InvisLocatorImpl implements InvisLocator {
     private final QueueRepository queueRepository;
     private final Clock clock;
@@ -97,6 +118,7 @@ public class InvisLocatorImpl implements InvisLocator {
     private final QueueDefinition queueDefinition;
     private Logger logger = getLogger(InvisLocatorImpl.class);
     private final DataContext dataContext;
+    private final ReaderBucketPointer currentReaderBucket;
 
 
     @Inject
@@ -112,6 +134,8 @@ public class InvisLocatorImpl implements InvisLocator {
         this.queueDefinition = queueDefinition;
         this.dataContext = dataContextFactory.forQueue(queueDefinition);
 
+        currentReaderBucket = dataContext.getPointerRepository().getReaderCurrentBucket();
+
         logger = logger.with("q", queueDefinition.getQueueName()).with("version", queueDefinition.getVersion());
     }
 
@@ -125,12 +149,12 @@ public class InvisLocatorImpl implements InvisLocator {
 
         if (messageAt == null) {
             // invis pointer points to garbage, try and find something else
-            return findAndConsumeNextVisible(pointer, invisiblity);
+            return findAndConsumeNextVisible(pointer, currentReaderBucket, invisiblity);
         }
 
-        if (messageAt.getDeliveryCount() == 0) {
-            // it hasn't been sent out for delivery yet so can't be invisible
-            // dont ever move past non delivered messages with invis
+        if (messageAt.isNotVisible(clock) && messageAt.isNotAcked()) {
+            // not acked, not visible, invis poiter is still valid
+            // do not advance
             return Optional.empty();
         }
 
@@ -146,56 +170,97 @@ public class InvisLocatorImpl implements InvisLocator {
             }
 
             // scan for the next visible if we have one
-            return findAndConsumeNextVisible(pointer, invisiblity);
+            return findAndConsumeNextVisible(pointer, currentReaderBucket, invisiblity);
         }
         else if (messageAt.isAcked()) {
             // current message is acked that the invis pointer was pointing to
             // try and move the invis pointer to the next lowest monotonic invisible
-            return findAndConsumeNextVisible(pointer, invisiblity);
+            return findAndConsumeNextVisible(pointer, currentReaderBucket, invisiblity);
         }
 
         return Optional.empty();
     }
 
     /**
-     * Either find an invis message to stop at, or look for messages that _were_ invis but
-     * now have come back alive.
+     * Either find an invis message to stop at,
      *
-     * @param pointer
+     * OR look for messages that _were_ invis but now have come back alive.
+     *
+     * OR a message that had an initial invis and was skipped by the reader (delivery count 0)
+     * and is now visible
+     *
+     * @param startingPointer
      * @param invisiblity
      * @return
      */
-    private Optional<Message> findAndConsumeNextVisible(final InvisibilityMessagePointer pointer, Duration invisiblity) {
+    private Optional<Message> findAndConsumeNextVisible(
+            final InvisibilityMessagePointer startingPointer,
+            final ReaderBucketPointer currentReaderBucketPointer,
+            final Duration invisiblity) {
+
+        InvisibilityMessagePointer activePointer = startingPointer;
+
+        while (true) {
+            final InvisBucketProcessResult invisBucketProcessResult = processBucket(activePointer, currentReaderBucketPointer, invisiblity);
+
+            switch(invisBucketProcessResult.getResultAction()){
+                case GoNext:
+                    activePointer = getPointerForNextBucket(activePointer);
+                    break;
+                case Stop:
+                    return invisBucketProcessResult.getMessage();
+            }
+        }
+    }
+
+    private InvisBucketProcessResult processBucket(
+            final InvisibilityMessagePointer activePointer,
+            final ReaderBucketPointer currentReaderBucketPointer,
+            final Duration invisiblity) {
         // check all the messages in the bucket the invis pointer is currently on
-        final ReaderBucketPointer bucketPointer = pointer.toBucketPointer(queueDefinition.getBucketSize());
+        final BucketPointer invisBucketPointer = activePointer.toBucketPointer(queueDefinition.getBucketSize());
 
-        final List<Message> messages = dataContext.getMessageRepository()
-                                                  .getMessages(bucketPointer);
+        final List<Message> messagesInBucket = dataContext.getMessageRepository()
+                                                          .getMessages(invisBucketPointer);
 
-        final BucketPointer maxMonotonBucketPointer = dataContext.getMonotonicRepository().getCurrent().toBucketPointer(queueDefinition.getBucketSize());
+        final BucketPointer maxMonotonBucketPointer = dataContext.getMonotonicRepository()
+                                                                 .getCurrent()
+                                                                 .toBucketPointer(queueDefinition.getBucketSize());
 
-        final BucketPointer invisBucketPointer = pointer.toBucketPointer(queueDefinition.getBucketSize());
-
-        if (messages.isEmpty() && invisBucketPointer.get() >= maxMonotonBucketPointer.get()) {
-            // no messages, and we're at the last bucket anyways, can't move pointer since nothing to move to
-            return Optional.empty();
+        // no messages, and we're at the last bucket anyways, can't move pointer since nothing to move to
+        if (messagesInBucket.isEmpty() && invisBucketPointer.get() >= maxMonotonBucketPointer.get()) {
+            return InvisBucketProcessResult.of(Optional.empty());
         }
 
-        if (stopAtInvisMessageInBucket(messages, pointer)) {
-            return Optional.empty();
+        // if the reader has moved past the current bucket, check
+        // if there are messages that are alive and were skipped
+        if (invisBucketPointer.get() < currentReaderBucketPointer.get()) {
+            // in the bucket, see if there is a revived message
+            final Optional<Message> newlyAliveMessage = consumeRevivedMessageInBucket(messagesInBucket, invisiblity, activePointer);
+
+            if (newlyAliveMessage.isPresent()) {
+                return InvisBucketProcessResult.of(newlyAliveMessage);
+            }
         }
 
-        final Optional<Message> newlyAliveMessage = consumeNewlyAliveMessageInBucket(messages, invisiblity, pointer);
-
-        if (newlyAliveMessage.isPresent()) {
-            return newlyAliveMessage;
+        // stop at the next invisible message in the bucket if there is one
+        // regardless of delivery status
+        if (stopAtInvisMessageInBucket(messagesInBucket, activePointer)) {
+            return InvisBucketProcessResult.of(Optional.empty());
         }
 
-        return tryConsumeNextVisibleMessage(getPointerForNextBucket(pointer), invisiblity);
+        // if we found a never delivered message in the bucket
+        // dont move past it. the normal reader flow will pick up
+        // this message, we dont want to claim it
+        if (stopAtNonDeliveredMessage(messagesInBucket, activePointer)) {
+            return InvisBucketProcessResult.of(Optional.empty());
+        }
+
+        return InvisBucketProcessResult.nextBucket();
     }
 
     /**
-     * in the active bucket, if there is a not acked, is currenlty invisible, and has been at least once delivered message
+     * in the active bucket, if there is a not acked, currently invisible
      * then if its ID is LESS than the current active pointer, move the pointer to that
      * otherwise pointer stays the same
      **/
@@ -203,14 +268,36 @@ public class InvisLocatorImpl implements InvisLocator {
 
         final Optional<Message> stoppingPoint = messages.stream()
                                                         .filter(m -> m.isNotAcked() &&
-                                                                     m.isNotVisible(clock) &&
-                                                                     m.getDeliveryCount() > 0).findFirst();
+                                                                     m.isNotVisible(clock)).findFirst();
 
         if (stoppingPoint.isPresent()) {
             trySetNewInvisPointer(pointer, stoppingPoint.get().getIndex());
 
             logger.with(stoppingPoint.get()).info("Found invis message in current bucket");
 
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * If there is a message in the bucket that was never delivered,
+     * dont move past it.
+     *
+     * @param messages
+     * @param pointer
+     * @return
+     */
+    private boolean stopAtNonDeliveredMessage(final List<Message> messages, final InvisibilityMessagePointer pointer) {
+        final Optional<Message> nonDeliveredInBucket = messages.stream().filter(i -> i.getDeliveryCount() == 0).findFirst();
+
+        if (nonDeliveredInBucket.isPresent()) {
+            // move pointer to start of bucket since invis isn't set to anything yet
+            // and this is going to be returned next
+            trySetNewInvisPointer(pointer, nonDeliveredInBucket.get().getIndex());
+
+            // don't move past a non delivered
             return true;
         }
 
@@ -225,26 +312,28 @@ public class InvisLocatorImpl implements InvisLocator {
      * @param currentPointer
      * @return
      */
-    private Optional<Message> consumeNewlyAliveMessageInBucket(
+    private Optional<Message> consumeRevivedMessageInBucket(
             final List<Message> messagesInBucket,
             final Duration invisiblity,
             InvisibilityMessagePointer currentPointer) {
-        // since we're scanning, look for a message that has been delivered
-        // is visible, and is not acked. this guy is now alive
-        final Optional<Message> nextNewlyAlive = messagesInBucket.stream()
-                                                                 .filter(m -> m.isNotAcked() && m.isVisible(clock) && m.getDeliveryCount() > 0)
+        // any message in the bucket that is revived (delivery count > 0 and is visible non-acked)
+        // OR a message that
+        final Optional<Message> revivedMessage = messagesInBucket.stream()
+                                                                 .filter(m -> m.isVisible(clock) && !m.isAcked())
                                                                  .findFirst();
 
-        if (nextNewlyAlive.isPresent()) {
+        if (revivedMessage.isPresent()) {
             // stop here since we're scanning and we can't have anyone else behind us
             // since they are either invis, OR they are acked
             // attempt to consume the message
-            final Optional<Message> tryConsumedMessage = dataContext.getMessageRepository().consumeMessage(nextNewlyAlive.get(), invisiblity);
+            final Optional<Message> tryConsumedMessage = dataContext.getMessageRepository()
+                                                                    .consumeMessage(revivedMessage.get(), invisiblity);
 
-            // if we were able to consume the message, try and move the invis pointer to this isnce its going to now be invis.
+            // if we were able to consume the message, try and move the invis pointer to this since its going to now be invis.
             // if someone else finds an earlier invis, it'll get moved to that
+            // we can do this only because we don't already have an invis pointer
             if (tryConsumedMessage.isPresent()) {
-                trySetNewInvisPointer(currentPointer, nextNewlyAlive.get().getIndex());
+                trySetNewInvisPointer(currentPointer, revivedMessage.get().getIndex());
 
                 return tryConsumedMessage;
             }

--- a/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
@@ -75,7 +75,6 @@ public class ReaderImpl implements Reader {
                                                                        .tryConsumeNextVisibleMessage(getCurrentInvisPointer(), invisibility);
 
         if (nowVisibleMessage.isPresent()) {
-
             logger.with(nowVisibleMessage.get()).info("Got newly visible message");
 
             return nowVisibleMessage;

--- a/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/reader/ReaderImpl.java
@@ -1,6 +1,7 @@
 package io.paradoxical.cassieq.workers.reader;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.godaddy.logging.Logger;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -16,12 +17,15 @@ import io.paradoxical.cassieq.model.PopReceipt;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.ReaderBucketPointer;
 import io.paradoxical.cassieq.model.time.Clock;
+import lombok.Cleanup;
 import org.joda.time.Duration;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
+import static com.codahale.metrics.MetricRegistry.name;
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
 public class ReaderImpl implements Reader {
@@ -31,8 +35,9 @@ public class ReaderImpl implements Reader {
     private final QueueRepository queueRepository;
     private final Clock clock;
     private final MetricRegistry metricRegistry;
+    private final InvisLocaterFactory invisLocaterFactory;
     private final QueueDefinition queueDefinition;
-    private final InvisLocatorImpl invisLocator;
+    private final Supplier<Timer.Context> timerSupplier;
 
     @Inject
     public ReaderImpl(
@@ -45,13 +50,15 @@ public class ReaderImpl implements Reader {
         this.queueRepository = queueRepository;
         this.clock = clock;
         this.metricRegistry = metricRegistry;
+        this.invisLocaterFactory = invisLocaterFactory;
         this.queueDefinition = queueDefinition;
 
         dataContext = dataContextFactory.forQueue(queueDefinition);
 
-        invisLocator = invisLocaterFactory.forQueue(queueDefinition);
-
         logger = logger.with("q", queueDefinition.getQueueName()).with("version", queueDefinition.getVersion());
+
+        timerSupplier = () -> metricRegistry.timer(name("reader", "queue", queueDefinition.getQueueName().get(), "v" + queueDefinition.getVersion()))
+                                            .time();
     }
 
     @Override
@@ -60,7 +67,12 @@ public class ReaderImpl implements Reader {
             return Optional.empty();
         }
 
-        final Optional<Message> nowVisibleMessage = invisLocator.tryConsumeNextVisibleMessage(getCurrentInvisPointer(), invisibility);
+        @SuppressWarnings("unused")
+        @Cleanup("stop")
+        final Timer.Context readerTimer = timerSupplier.get();
+
+        final Optional<Message> nowVisibleMessage = invisLocaterFactory.forQueue(queueDefinition)
+                                                                       .tryConsumeNextVisibleMessage(getCurrentInvisPointer(), invisibility);
 
         if (nowVisibleMessage.isPresent()) {
 
@@ -88,7 +100,7 @@ public class ReaderImpl implements Reader {
 
         if (messageAt.getVersion() != popReceipt.getMessageVersion() ||
             !messageAt.getTag().equals(popReceipt.getMessageTag())) {
-            
+
             return false;
         }
 
@@ -147,7 +159,10 @@ public class ReaderImpl implements Reader {
 
     private void tombstone(final ReaderBucketPointer bucket) {
         if (dataContext.getMessageRepository().tombstone(bucket)) {
-            logger.with(bucket).info("Tombestoned reader");
+            logger.with(bucket).info("Tombstoned reader");
+        }
+        else {
+            logger.with(bucket).info("Reader bucket was already tombstoned");
         }
     }
 

--- a/core/src/main/java/io/paradoxical/cassieq/workers/repair/RepairWorkerImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/repair/RepairWorkerImpl.java
@@ -151,6 +151,8 @@ public class RepairWorkerImpl implements RepairWorker {
         }
         else{
             danglingDetectedCounter.run();
+
+            dataContext.getMessageRepository().finalize(context.getPointer());
         }
     }
 
@@ -230,6 +232,9 @@ public class RepairWorkerImpl implements RepairWorker {
             dataContext.getMessageRepository().deleteAllMessages(currentBucket);
 
             deletingFinalizedCounter.run();
+        }
+        else{
+            dataContext.getMessageRepository().finalize(currentBucket);
         }
     }
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
@@ -5,13 +5,7 @@ import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.DataContext;
 import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.factories.ReaderFactory;
-import io.paradoxical.cassieq.model.BucketSize;
-import io.paradoxical.cassieq.model.Message;
-import io.paradoxical.cassieq.model.MessageUpdateRequest;
-import io.paradoxical.cassieq.model.MonotonicIndex;
-import io.paradoxical.cassieq.model.PopReceipt;
-import io.paradoxical.cassieq.model.QueueDefinition;
-import io.paradoxical.cassieq.model.QueueName;
+import io.paradoxical.cassieq.model.*;
 import io.paradoxical.cassieq.unittests.time.TestClock;
 import io.paradoxical.cassieq.workers.reader.Reader;
 import lombok.Data;
@@ -69,6 +63,10 @@ public class ReaderTester extends TestBase {
             putMessage(0, blob);
         }
 
+        public MonotonicIndex ghostMessage() {
+            return context.getMonotonicRepository().nextMonotonic();
+        }
+
         private void putMessage(int seconds, String blob) throws Exception {
 
             final MonotonicIndex monoton = context.getMonotonicRepository().nextMonotonic();
@@ -93,10 +91,75 @@ public class ReaderTester extends TestBase {
         private boolean readAndAckMessage(String blob) {
             return readAndAckMessage(blob, 10L);
         }
+
+        private void tombstone(int bucket){
+            context.getMessageRepository().tombstone(ReaderBucketPointer.valueOf(bucket));
+        }
+
+        private void finalize(int bucket){
+            context.getMessageRepository().finalize(RepairBucketPointer.valueOf(bucket));
+        }
     }
 
     @Before
     public void setup() {
+    }
+
+    @Test
+    public void invis_stops_non_finalized_bucket() throws Exception {
+        final ReaderQueueContext testContext = setupTestContext("invis_stops_non_finalized_bucket", 3);
+
+        testContext.putMessage(0, "1");
+        testContext.putMessage(3, "2");
+
+        testContext.ghostMessage();
+
+        testContext.putMessage(0, "4 (new bucket)");
+        testContext.putMessage(30, "5");
+        testContext.putMessage(20, "6");
+
+        testContext.readAndAckMessage("1");
+
+        // 2 is invis, 3 is a ghost
+        testContext.readAndAckMessage("4 (new bucket)");
+
+        assertThat(testContext.readNextMessage(10)).isEmpty();
+
+        getTestClock().tickSeconds(10L);
+
+        // 2 is alive now
+        final Message messageTwo = testContext.readNextMessage(1).get();
+
+        // 2 is now invis, 5 and 6 are still blocked
+        assertThat(testContext.readNextMessage(0)).isEmpty();
+
+        // 2 is expired, should come back from invis
+        getTestClock().tickSeconds(2L);
+
+        testContext.readAndAckMessage("2");
+
+        final InvisibilityMessagePointer currentInvisPointer = testContext.getContext().getPointerRepository().getCurrentInvisPointer();
+
+        // it should point to message 2
+        assertThat(currentInvisPointer.get()).isEqualTo(1);
+
+        // repair worker processed and closed bucket 0 off
+        testContext.finalize(0);
+
+        // invis can now move on since all messages are ack'd in bucket 0
+        // and there will be no more publishes (its been finalized)
+
+        // however, message 5 is still invis
+        assertThat(testContext.readNextMessage(10)).isEmpty();
+
+        // but validate that the invis points to 5
+
+        final InvisibilityMessagePointer nextInvisPointer = testContext.getContext().getPointerRepository().getCurrentInvisPointer();
+
+        // it should point to message 5
+        final Message messageFive = testContext.getContext().getMessageRepository().getMessage(nextInvisPointer);
+
+        assertThat(messageFive.getBlob()).isEqualTo("5");
     }
 
     @Test

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/server/SelfHostServer.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/server/SelfHostServer.java
@@ -52,6 +52,10 @@ public class SelfHostServer implements AutoCloseable {
         serviceConfigurationTestServiceServiceTestRunner.run(serviceConfiguration, ImmutableList.copyOf(overridableModules));
     }
 
+    public TestService getService(){
+        return serviceConfigurationTestServiceServiceTestRunner.getApplication();
+    }
+
     public void start() {
         start(getDefaultConfig());
     }


### PR DESCRIPTION
We had chatted about sort of doing bucketizing with invis pointer and that is kind of going on here (though its a mix between bucket and pointer usages).

The goal is to improve searching for invis by making basic checkpoints and to make sure we properly move behind the reader picking up messages. We were mostly doing this before, but I have unwound the recursion (it made things a tad messy, open to suggestions), and to make sure we actually set the invis pointer when we can make a checkpoint instead of just doing it all in memory.

Here is what is in this PR:
- First check the current invis pointer. If it is still valid, end processing of invis.  If it is not valid, attempt to scan the bucket
- In a bucket, if we have 
  - A revived message, return it. This is a message that was skipped by the reader since it was invis, and the reader has since moved on into another bucket (so it won't ever see it). Try and mark the current invis to this, since we're actively looking for a new valid invis pointer.  
  - A still invis message. Obviously if we find an invis message, we should try and mark ourselves here and return.  
  - A non-delivered message. If we encounter a bucket that has a non delivered message, don't do anything with the pointer but just return no invis.  We will have to scan this bucket again later
  - If all the messages are acked then go to the next bucket

All `_try and mark_ are optimistic, in that we try and set the next iteration to what the try returned. This means that if multiple readers are scanning the buckets and one moves the invis pointer backwards, the other readers should eventually respect that.  

That said, determining if all messages ack'd proves challenging, since in another PR we had the repair worker (optionally) delete all messages.  Now its complicated to answer _am i on a bucket with no messages, or am i on a bucket that was finalized_.  To solve that, I added a new special index called `Finalize`.  After messages are deleted in a bucket by the repair worker, he adds the `Finalize` index. The sucky thing here is that we no longer have _true_ message cleanup, though I think this is OK for bookkeeping. When we delete a queue, we can go through and clean up all the finalizer indexes. This makes delete actually kind of easier, since we just go from 0 to monoton and delete.  Especially if delete is an async job, then its ok if it takes a while to go through.

All messages acked now means:
- # acked == bucket size
- all acked < bucket size BUT finalizer exists

Since the repair worker WILL NOT delete a bucket if there are unacked messages, we can have messages that are unacked in a finalized bucket.

Deleting all messages in an ack'd bucket needs to be discussed anyways, since we can have unacked messages in a finalized bucket (so that disallows a delete), and if we choose to delete messages on ack (if the bucket is finalized) then we need to make sure to keep the finalizer index.  Cassandra actually supports batch queries, so maybe we can actually do a transaction batch in those cases? 

I'm sort of ranting now, but to solve the delete leak we could just introduce a max message TTL and have them clean up themselves, and we can try our best to clean up in the happy path and just ignore the rest.
