### PR TITLE
Adding config dump command

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -1,10 +1,12 @@
 FROM java:8
 
-ADD data /data
-
-RUN curl -O https://oss.sonatype.org/content/repositories/snapshots/io/paradoxical/cassandra.loader/1.0-SNAPSHOT/cassandra.loader-1.0-20151203.021931-4-runner.jar && \
+# load the cassadanra loader first, since this wont change much
+RUN curl -O -s https://oss.sonatype.org/content/repositories/snapshots/io/paradoxical/cassandra.loader/1.0-SNAPSHOT/cassandra.loader-1.0-20151203.021931-4-runner.jar && \
             mkdir -p /data/tools && \
             mv cassandra.loader-1.0-20151203.021931-4-runner.jar /data/tools/cassandra-loader.jar
+
+# add the new jar/configs
+ADD data /data
 
 # set the service to run
 ENTRYPOINT ["/data/bin/service"]

--- a/core/docker/data/bin/service
+++ b/core/docker/data/bin/service
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
+conf_dir=/data/conf
+
+libs_dir=/data/lib
+
+configFile=$conf_dir/configuration.yml
+
 function run_app(){
 
     classname="io.paradoxical.cassieq.ServiceApplication"
 
-    command="server"
-
-    conf_dir=/data/conf
-
-    libs_dir=/data/lib
+    command=$1
 
     for jar in ${libs_dir}/*.jar; do
         classpath=$classpath:$jar
@@ -28,9 +30,7 @@ function run_app(){
 
     echo "USING JAVA DEBUG $properties"
 
-    configFile=$conf_dir/configuration.yml
-
-    cmd="java $properties -cp $classpath $classname $command $configFile"
+    cmd="java $properties -cp $classpath $classname $command"
 
     echo ${cmd}
 
@@ -47,11 +47,18 @@ function boostrap(){
         "$@"
 }
 
-if [ "$1" == "bootstrap" ]; then
-    shift
-    boostrap $@
-elif [ "$1" == "debug" ]; then
-    exec /bin/bash
-else
-    run_app
-fi
+case "$1" in
+    "bootstrap")
+        shift
+        bootstrap $@;;
+
+    "debug")
+        shift
+        exec /bin/bash;;
+
+    "default-config")
+        run_app "config -a $configFile";;
+
+    *)
+        run_app "server $configFile";;
+esac

--- a/core/docker/data/bin/service
+++ b/core/docker/data/bin/service
@@ -18,21 +18,21 @@ function run_app(){
 
     properties="-Djava.library.path=${libs_dir} "
 
-    properties="${properties} -Dcom.sun.management.jmxremote.rmi.port=1898"
-    properties="${properties} -Dcom.sun.management.jmxremote.port=1898"
-    properties="${properties} -Dcom.sun.management.jmxremote.ssl=false"
-    properties="${properties} -Dcom.sun.management.jmxremote.authenticate=false"
-    properties="${properties} -Djava.rmi.server.hostname=${HOST_IPADDR}"
+    if [ "${ENABLE_JMX}" == "true" ] ; then
+        properties="${properties} -Dcom.sun.management.jmxremote.rmi.port=1898"
+        properties="${properties} -Dcom.sun.management.jmxremote.port=1898"
+        properties="${properties} -Dcom.sun.management.jmxremote.ssl=false"
+        properties="${properties} -Dcom.sun.management.jmxremote.authenticate=false"
+        properties="${properties} -Djava.rmi.server.hostname=${HOST_IPADDR}"
+    fi
 
     if [ "${DEBUG_JAVA}" == "true" ]; then
         properties="$properties -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=1044"
+
+        echo "USING JAVA DEBUG $properties"
     fi
 
-    echo "USING JAVA DEBUG $properties"
-
     cmd="java $properties -cp $classpath $classname $command"
-
-    echo ${cmd}
 
     exec ${cmd}
 }
@@ -47,6 +47,27 @@ function boostrap(){
         "$@"
 }
 
+function printHelp(){
+echo """
+Welcome to CassieQ!  This docker image contains several modes of execution to help you configure and run CassieQ.
+
+1. bootstrap.  This mode populates (and upgrades) a cassandra keyspace to be useable with cassieq. It takes the following environment variables:
+
+KEYSPACE='cassandra keyspace to use for cassieq'
+CONTACT_POINTS='contact point'
+USERNAME=''
+PASSWORD=''
+
+2. help. This menu
+
+3. debug.  Debug starts in an empty shell and lets you bypass normal startup mode
+
+4. default-config.  This prints out the CassieQ default config (with your normal CassieQ environemnt variables applied)
+in order for you to create a customized config file to place in a virtual mount at /data/conf
+
+For more information see our github at http://github.com/paradoxical-io/cassieq"""
+}
+
 case "$1" in
     "bootstrap")
         shift
@@ -58,6 +79,9 @@ case "$1" in
 
     "default-config")
         run_app "config -a $configFile";;
+
+    "help")
+        printHelp;;
 
     *)
         run_app "server $configFile";;

--- a/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
+++ b/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
@@ -12,6 +12,7 @@ import io.dropwizard.views.ViewBundle;
 import io.dropwizard.views.ViewRenderer;
 import io.dropwizard.views.mustache.MustacheViewRenderer;
 import io.paradoxical.cassieq.bundles.GuiceBundleProvider;
+import io.paradoxical.cassieq.commands.ConfigDumpCommand;
 import io.paradoxical.cassieq.configurations.LogMapping;
 import io.paradoxical.cassieq.serialization.JacksonJsonMapper;
 import io.paradoxical.common.web.web.filter.CorrelationIdFilter;
@@ -59,13 +60,13 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
 
     @Override
     public void initialize(Bootstrap<ServiceConfiguration> bootstrap) {
+        bootstrap.addCommand(new ConfigDumpCommand());
+
         bootstrap.addBundle(new TemplateConfigBundle());
 
         initializeViews(bootstrap);
 
         initializeDepedencyInjection(bootstrap);
-
-
     }
 
     public void stop() {

--- a/core/src/main/java/io/paradoxical/cassieq/commands/ConfigDumpCommand.java
+++ b/core/src/main/java/io/paradoxical/cassieq/commands/ConfigDumpCommand.java
@@ -1,0 +1,65 @@
+package io.paradoxical.cassieq.commands;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import io.dropwizard.cli.Command;
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.ConfigurationFactoryFactory;
+import io.dropwizard.setup.Bootstrap;
+import io.paradoxical.cassieq.ServiceConfiguration;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+
+public class ConfigDumpCommand extends Command {
+
+    public ConfigDumpCommand() {
+        super("config", "Prints out default config settings for use in creating custom config files");
+    }
+
+    @Override
+    public void configure(final Subparser subparser) {
+        subparser.addArgument("-a", "--app-config")
+                 .dest("app")
+                 .type(String.class)
+                 .help("Print app yaml");
+    }
+
+    @Override
+    public void run(final Bootstrap<?> bootstrap, final Namespace namespace) throws Exception {
+        final Bootstrap<ServiceConfiguration> serviceConfigurationBootstrap = (Bootstrap<ServiceConfiguration>) bootstrap;
+
+        final String configPath = namespace.getString("app");
+
+        if (configPath != null) {
+            printDefaultAppValues(configPath, serviceConfigurationBootstrap);
+        }
+    }
+
+    private void printDefaultAppValues(final String configPath, final Bootstrap<ServiceConfiguration> bootstrap) throws IOException, ConfigurationException {
+        final ConfigurationFactoryFactory<ServiceConfiguration> configurationFactoryFactory = bootstrap.getConfigurationFactoryFactory();
+
+        final ConfigurationFactory<ServiceConfiguration> configurationFactory =
+                configurationFactoryFactory.create(ServiceConfiguration.class,
+                                                   bootstrap.getValidatorFactory().getValidator(),
+                                                   bootstrap.getObjectMapper(),
+                                                   StringUtils.EMPTY);
+
+        final ServiceConfiguration config = configurationFactory.build(bootstrap.getConfigurationSourceProvider(), configPath);
+
+        final YAMLFactory yamlFactory = new YAMLFactory();
+
+        yamlFactory.configure(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID, false);
+
+        final ObjectMapper objectMapper = new ObjectMapper(yamlFactory);
+
+        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+
+        System.out.println(objectMapper.writeValueAsString(config));
+    }
+}


### PR DESCRIPTION
Fixes #5 

Now running `paradoxical/cassieq default-config` gives you the full config (with all defaults applied).

```
cassandra:
  clusterName: "cassieq"
  keyspace: "xxx"
  validationQuery: "SELECT * FROM system.schema_keyspaces"
  contactPoints:
  - "10.22.240.181"
  port: 9042
  protocolVersion: null
  compression: "NONE"
  reconnectionPolicy:
    type: "exponential"
    baseDelay: "1 second"
    maxDelay: "30 seconds"
  authProvider:
    type: "plainText"
    username: "xxx"
    password: "xxx"
  retryPolicy: null
  loadBalancingPolicy: null
  speculativeExecutionPolicy: null
  queryOptions:
    fetchSize: 5000
    defaultIdempotence: false
    metadataEnabled: true
    maxPendingRefreshNodeListRequests: 20
    maxPendingRefreshNodeRequests: 20
    maxPendingRefreshSchemaRequests: 20
    refreshNodeListIntervalMillis: 1000
    refreshNodeIntervalMillis: 1000
    refreshSchemaIntervalMillis: 1000
    reprepareOnUp: true
    prepareOnAllHosts: true
    serialConsistencyLevel: "LOCAL_SERIAL"
    consistencyLevel: "LOCAL_QUORUM"
  socketOptions:
    connectTimeoutMillis: 5000
    readTimeoutMillis: 12000
    keepAlive: true
    reuseAddress: null
    soLinger: null
    tcpNoDelay: true
    receiveBufferSize: null
    sendBufferSize: null
  poolingOptions:
    heartbeatInterval: null
    poolTimeout: null
    remote:
      minSimultaneousRequests: 1
      maxSimultaneousRequests: 500
      coreConnections: 1
      maxConnections: 500
    local:
      minSimultaneousRequests: 1
      maxSimultaneousRequests: 1500
      coreConnections: 1
      maxConnections: 1500
  metricsEnabled: true
  jmxEnabled: false
  shutdownGracePeriod: "30 seconds"
  ssl: null
  casConfig:
    enabled: true
    waitTimeMs: 25
    maxWaitTimeMs: 250
    maxRetries: 3
repair:
  managerRefreshRateSeconds: 60
log:
  logRawJerseyRequests: false
clustering:
  enabled: true
  lockWaitSeconds: 15
  clusterPassword: "cassieq"
  clusterName: "cassieq"
  multicastGroup: "224.2.2.3"
  multicastPort: 54327
  overridePath: "/data/conf/cluster/hazelcast.config"
allocation:
  strategy: "CLUSTER"
  manualAllocatorsCount: null
  manualAllocatorInstanceNumber: null
server:
  type: "default"
  maxThreads: 1024
  minThreads: 8
  maxQueuedRequests: 1024
  idleThreadTimeout: "1 minute"
  nofileSoftLimit: null
  nofileHardLimit: null
  gid: null
  uid: null
  user: null
  group: null
  umask: null
  startsAsRoot: null
  registerDefaultExceptionMappers: true
  shutdownGracePeriod: "30 seconds"
  allowedMethods:
  - "GET"
  - "POST"
  - "PUT"
  - "DELETE"
  - "HEAD"
  - "OPTIONS"
  - "PATCH"
  applicationConnectors:
  - type: "http"
    port: 8080
    bindHost: null
    headerCacheSize: "512 bytes"
    outputBufferSize: "32 kilobytes"
    maxRequestHeaderSize: "8 kilobytes"
    maxResponseHeaderSize: "8 kilobytes"
    inputBufferSize: "8 kilobytes"
    idleTimeout: "30 seconds"
    minBufferPoolSize: "64 bytes"
    bufferPoolIncrement: "1024 bytes"
    maxBufferPoolSize: "64 kilobytes"
    acceptorThreads: 4
    selectorThreads: 8
    acceptQueueSize: null
    reuseAddress: true
    soLingerTime: null
    useServerHeader: false
    useDateHeader: true
    useForwardedHeaders: true
  adminConnectors:
  - type: "http"
    port: 8081
    bindHost: null
    headerCacheSize: "512 bytes"
    outputBufferSize: "32 kilobytes"
    maxRequestHeaderSize: "8 kilobytes"
    maxResponseHeaderSize: "8 kilobytes"
    inputBufferSize: "8 kilobytes"
    idleTimeout: "30 seconds"
    minBufferPoolSize: "64 bytes"
    bufferPoolIncrement: "1024 bytes"
    maxBufferPoolSize: "64 kilobytes"
    acceptorThreads: 4
    selectorThreads: 8
    acceptQueueSize: null
    reuseAddress: true
    soLingerTime: null
    useServerHeader: false
    useDateHeader: true
    useForwardedHeaders: true
  adminMaxThreads: 64
  adminMinThreads: 1
  applicationContextPath: "/"
  adminContextPath: "/"
  rootPath: "/"
  requestLog:
    timeZone: "UTC"
    appenders:
    - type: "console"
      threshold:
        levelInt: -2147483648
        levelStr: "ALL"
      logFormat: null
      queueSize: 256
      discardingThreshold: -1
      includeCallerData: false
      timeZone: "UTC"
      target: "STDOUT"
  gzip:
    enabled: true
    minimumEntitySize: "256 bytes"
    bufferSize: "8 kilobytes"
    excludedUserAgents: []
    excludedUserAgentPatterns: []
    compressedMimeTypes: []
    includedMethods: []
    gzipCompatibleDeflation: true
    gzipCompatibleInflation: true
    vary: "Accept-Encoding"
    deflateCompressionLevel: -1
logging:
  type: "default"
  level:
    levelInt: 20000
    levelStr: "INFO"
  loggers:
    com.godaddy.domains: "ALL"
    com.sun.jersey.api.container.filter.LoggingFilter: "INFO"
  appenders:
  - type: "console"
    threshold:
      levelInt: 20000
      levelStr: "INFO"
    logFormat: "%d [%p] %marker [%mdc{corrId}] %logger %m%n"
    queueSize: 256
    discardingThreshold: -1
    includeCallerData: false
    timeZone: "UTC"
    target: "STDERR"
  - type: "file"
    threshold:
      levelInt: -2147483648
      levelStr: "ALL"
    logFormat: null
    queueSize: 256
    discardingThreshold: -1
    includeCallerData: false
    currentLogFilename: "/data/logs/debug.log"
    archive: true
    archivedLogFilenamePattern: "/data/logs/debug-%d.log.gz"
    archivedFileCount: 5
    maxFileSize: null
    timeZone: "UTC"
  - type: "file"
    threshold:
      levelInt: 30000
      levelStr: "WARN"
    logFormat: null
    queueSize: 256
    discardingThreshold: -1
    includeCallerData: false
    currentLogFilename: "/data/logs/error.log"
    archive: true
    archivedLogFilenamePattern: "/data/logs/error-%d{yyyy-MM-dd-hh}.log.gz"
    archivedFileCount: 6
    maxFileSize: null
    timeZone: "UTC"
metrics:
  frequency: "1 minute"
  reporters:
  - type: "graphite"
    durationUnit: "MILLISECONDS"
    rateUnit: "SECONDS"
    excludes: []
    includes: []
    frequency:
      present: true
    useRegexFilters: false
    host: "192.168.99.100"
    port: 2003
    prefix: ""
```
