### PR TITLE
Exposing permissions api to generate query string auth, plus tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
-sudo: false
 language: java
 jdk:
 - oraclejdk8
-cache:
-  directories:
-  - $HOME/.m2
 after_success:
 - ./deploy.sh
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: java
 jdk:
-- oraclejdk8
+  - oraclejdk8
+before_install:
+  - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 after_success:
-- ./deploy.sh
+  - ./deploy.sh
 services:
-- docker
+  - docker
 notifications:
   slack:
     secure: f7MqnZutKlPgpbOdO+q+6NyY4icF2P7hjxDy2cV4ahz8OrT70YGufVVZK41JS/j9RzO9dDKIpEuMqEfQpAZrtcqqui1iWcYE9ziRG8N+8ROW05ohzM+wLsCUW8xXtAr1+A1UEm/PPlQ9yZrffpZ86XXgTGiA+Auu6gwPJ/9TioQcShm/K0kDdkdYoE7Vj78X56HkfWjQYFtuwyOggL46Rgx1Em0bbTlDFLZrmaK4cLgmNYcO+21FpW/26D9dzi1coCqEkSHkiDmZlJ6ur0X5pLvzOZhOl9An+z+/3TKuqVLSor6ggSDfy/Oq3QoRj0Rp0YuJAjvXAssiZQGHlIBUJ7tI48COEFvGp2JqJHJpq5wTuTApIR20g8bPE7aNtxuhF9lvsXQLi/smA1vXvAM3JZ2qJkFm9OQd04oVnfploD8NYn1cq3/XswXKilEtORlH3ta4wxnf36RvIAn5sYSAGlf6x8+q6ncBtRBXkUbvzZTuFCiGTvdbHF2I3AmpYUKN+rljN4qiYjmZYZZWPkwFA/mqGq1CI9BldHhqF7GGsQmHdHXS2GS04nHzzOIGdRkaRfWUVG4myWPo+XiD+k5TIeNXnPuI0DabZmIuceQZQZVl58CUT5t3UZU2/TfAAEBh/tZzzCzMCoTOgxoRN8j8H+oyaObyfe6Sl0YkvSi4Yg8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: java
+sudo: false
 jdk:
   - oraclejdk8
+
+  # https://github.com/travis-ci/travis-ci/issues/4629 container based travis
+  # is referencing codehause which was depcreated is now completely dead.
+  # this forces the default settings to use sontaype
+cache:
+  directories:
+  - $HOME/.m2
 before_install:
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 after_success:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ io.paradoxical.cassieq
 ![Build status](https://travis-ci.org/paradoxical-io/cassieq.svg?branch=master)
 
 CassieQ is a distributed queue built on cassandra. Yes, we know, queues on cassandra are an anti-pattern,
-but only when you use secondary indexes, and lots of polls and scans which CassieQ _doesn't_ do.
+but CassieQ leverages lightweight transactions and message bucketizing to avoid issues with queues based off deletes.
 
 CassieQ provides:
 
@@ -12,6 +12,8 @@ CassieQ provides:
 - invisiblity of messages
 - simple API of get/ack
 - highly scaleable
+- authentication
+- queue statistics (via graphite)
 
 ## To run
 
@@ -83,66 +85,10 @@ CassieQ is fully encapsulated and only needs to know your cassandra information.
 passing the cassandra cluster credentials and connection information via docker env vars and auto populating
 the tracking tables for queues.
 
-## How does CassieQ work?
 
-Messages are put into a queue and can be read from the queue with a visiblity timeout. This means
-that if the message isn't acked within the visiblity timeout it becomes visible again.  Most other queue systems
-deal with this by detecting severed connections but since angenlahir is http based and connectionless we can't rely on that.
+## Admin panel
 
-
-CassieQ works with 3 pointers into a queue.
-
-- A reader bucket pointer
-- A repair bucket pointer
-- An invisiblity pointer
-
-These three pointers will be discussed in each section
-
-In order to scale and efficiently act as a queue we need to leverage cassandra partitioning capabilities.
-Queues are actually messages bucketized into a fixed size group called a bucket.   
-Each message is assigned a monotonically increasing id that maps itself into a bucket. 
-
-For example, if the bucket is size 20 and you have id 21, that maps into bucket 1 (21/20).  
-
-Messages are always put into the bucket they correlate to, regardless if previous buckets are full.
-
-The reader has a pointer to its active bucket (the reader buket pointer) and scans the bucket for unacked visible messages.  If the bucket is full
-it tombstones the bucket indicating that the bucket is closed for processing.  If the bucket is NOT full, but all messages
-in the bucket are consumed (or being processed) AND the monotonic pointer has already advanced to the next bucket,t he current 
-bucket is also tombstoned. This means no more messages will ever show up in the current bucket... sort of
-
-### Repairing delayed writes
-
-There is a condition that you can have a delayed write. For example, assume you generate monotonic ids in this sequence:
-
-```
-Id 19
-Id 20
-Write 20
-Write 19
-```
-
-In this scenario id 20 advances the monotonic bucket to bucket 1 (given buckets are size 20).  That means the reader tombstones
-bucket 0. But what happenes to message 19? We don't want to lose it, but as far as the reader is concnered its moved onto bucket 1 and off of bucket 0.
-
-This is where the concept of a repair worker comes into play. The repair worker's job is to slowly follow the reader and wait for tombstoned buckets. It 
-has its own pointer (the repair bucket pointer)
-
-If a bucket is tombstoned the repair worker will wait for a configured timeout for _out of order missing messages_ to appear. This means if a slightly
-delayed write occurs then the repair worker will actually pick it up and then _republish it_ to the last active bucket.
-
-This means we don't necessarily guarantee FIFO, however we do guarantee messages will appear.
-
-### Invisibility
-
-Now the question comes up as how to deal with invsibility of messages. For this there is a separate pointer tracking 
-the last invisible pointer.  When a read comes in, we first check the invsiblity pointer to see if that message is now visible.
-
-If it is, we can return it. If not, get the next available message.  
-
-If the current invisible pointer is already acked then we need to find the next invisible pointer. This next invisible pointer is the first
-non-acked non-visible message. If there isn't one in the current bucket, the invisibility pointer moves to the next bucket until it finds one 
-or no messages exist.
+The admin API is available at `host:8081/admin`
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ Execute cassieq local
 
 ```
 ./scripts/run-core.sh
-```
+``` 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ permission based url params for them. This may look of the form:
 Which can be appended to any API url.  The auth is of a simple form (concatenation of single character based permissions) which in this scenario indicates
 
 ```
-Put (p)
-Update (u)
-Add (a)
-Get (g)
+PutMessage (p)
+UpdateMessage (u)
+AckMessage (a)
+GetQueueInformation (g)
 ```
 
 For a full list of granular permissions go to the admin panel permissions api.  

--- a/README.md
+++ b/README.md
@@ -102,6 +102,73 @@ We have bundled a java client to talk to a simple rest api. The api supports
 Getting a message gives you a pop reciept that encodes the message index AND its version. This means that you can prevent multiple ackers of a message
 and do conditional atomic actions based on that message version.
 
+## Authentication
+
+CassieQ has three forms of authentication
+ 
+- Global account access via key
+- Endpoint signing by key
+- Granular access via permission claims by account
+ 
+### Claims
+
+Claims by account is the preferred method. To generate a claim for a user, you can create a named account key for that group (such as "ui-members") and create
+permission based url params for them. This may look of the form:
+
+```
+?auth=puag&sig=NygRs9GBh9n_i2s7KTMof0us-RXm5nt3RnlWKb3N15A
+```
+
+Which can be appended to any API url.  The auth is of a simple form (concatenation of single character based permissions) which in this scenario indicates
+
+```
+Put (p)
+Update (u)
+Add (a)
+Get (g)
+```
+
+For a full list of granular permissions go to the admin panel permissions api.  
+
+The advantage to transparent signature based auth is that you can pass the url to multiple teams and share common auth without leaking secrets.  To revoke access, 
+delete the key that was used to generate the signature.
+
+### Global
+
+This generates global access by account.
+
+Global account access is via header parameters. Add your account key as the authorization header with the value
+
+```
+Key: <your key>
+```
+
+### Endpoint singing by key
+
+This also provides global access by account.
+
+Generate auth tokens by signing using Hmac256 the following:
+
+```
+AccountName
+RequestMethod
+/RequestPath
+```
+
+For example
+
+```
+TestAccount
+GET
+/api/v1/accounts/TestAccount/queues/foo/messages/next
+```
+
+And taking this signed value and putting it in the auth header as 
+
+```
+Signed: <signature>
+```
+
 Execute cassieq local
 ====
 

--- a/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqApi.java
+++ b/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqApi.java
@@ -38,7 +38,7 @@ public interface CassieqApi {
         OkHttpClient client = new OkHttpClient();
         client.interceptors().add(chain -> {
             final Request request = chain.request();
-            
+
             return chain.proceed(cassieqCredentials.authorize(request));
         });
 

--- a/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqApi.java
+++ b/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqApi.java
@@ -22,8 +22,6 @@ import retrofit.http.Path;
 import retrofit.http.Query;
 
 import java.net.URI;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
@@ -40,14 +38,8 @@ public interface CassieqApi {
         OkHttpClient client = new OkHttpClient();
         client.interceptors().add(chain -> {
             final Request request = chain.request();
-            try {
-                return chain.proceed(cassieqCredentials.authorize(request));
-            }
-            catch (InvalidKeyException | NoSuchAlgorithmException e) {
-                logger.error(e, "Error authorizing credentials!");
-
-                throw new RuntimeException("Error authorizing credentials!", e);
-            }
+            
+            return chain.proceed(cassieqCredentials.authorize(request));
         });
 
         Retrofit retrofit = new Retrofit.Builder()

--- a/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
+++ b/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
@@ -35,15 +35,8 @@ public interface CassieqCredentials {
                                            .requestMethod(request.method())
                                            .build();
 
-            final String signature;
-            try {
-                signature = requestParameters.computeSignature(accountKey);
-            }
-            catch (InvalidKeyException | NoSuchAlgorithmException e) {
-                logger.error(e, "Error computing siganture!");
 
-                throw new RuntimeException(e);
-            }
+            final String signature = requestParameters.computeSignature(accountKey);
 
             return request.newBuilder()
                           .header("Authorization", "Signed " + signature)

--- a/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
+++ b/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
@@ -11,8 +11,6 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -20,11 +18,6 @@ import java.util.Map;
 @FunctionalInterface
 public interface CassieqCredentials {
     static CassieqCredentials key(final AccountName accountName, final AccountKey accountKey) throws NoSuchAlgorithmException, InvalidKeyException {
-        final String hmacSHA2561Algo = "HmacSHA256";
-        final Mac hmacSHA256 = Mac.getInstance(hmacSHA2561Algo);
-
-        hmacSHA256.init(new SecretKeySpec(accountKey.getBytes(), hmacSHA2561Algo));
-
         final DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.dateTime();
 
         return request -> {
@@ -37,7 +30,7 @@ public interface CassieqCredentials {
                                            .requestMethod(request.method())
                                            .build();
 
-            final String signature = requestParameters.computeSignature(hmacSHA256);
+            final String signature = requestParameters.computeSignature(accountKey);
 
             return request.newBuilder()
                           .header("Authorization", "Signed " + signature)
@@ -69,5 +62,5 @@ public interface CassieqCredentials {
         };
     }
 
-    Request authorize(Request request);
+    Request authorize(Request request) throws NoSuchAlgorithmException, InvalidKeyException;
 }

--- a/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
+++ b/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
@@ -67,7 +67,6 @@ public interface CassieqCredentials {
                           .url(newUrlBuilder.build())
                           .build();
         };
-
     }
 
     Request authorize(Request request);

--- a/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
+++ b/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
@@ -37,7 +37,7 @@ public interface CassieqCredentials {
                                            .build();
 
 
-            final String signature = requestParameters.computeSignature(MacProviders.Hmac256(accountKey));
+            final String signature = requestParameters.computeSignature(MacProviders.HmacSha256(accountKey));
 
             return request.newBuilder()
                           .header("Authorization", "Signed " + signature)

--- a/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
+++ b/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqCredentials.java
@@ -6,6 +6,7 @@ import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.Request;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.auth.MacProviders;
 import io.paradoxical.cassieq.model.auth.SignedRequestParameters;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -36,7 +37,7 @@ public interface CassieqCredentials {
                                            .build();
 
 
-            final String signature = requestParameters.computeSignature(accountKey);
+            final String signature = requestParameters.computeSignature(MacProviders.Hmac256(accountKey));
 
             return request.newBuilder()
                           .header("Authorization", "Signed " + signature)

--- a/core/docker/data/conf/configuration.yml
+++ b/core/docker/data/conf/configuration.yml
@@ -75,7 +75,7 @@ logging:
   appenders:
     # Log warnings and errors to stderr
     - type: console
-      threshold: INFO
+      threshold: DEBUG
       target: stderr
       logFormat: "%d [%p] %marker [%mdc{corrId}] %logger %m%n"
 

--- a/core/docker/data/conf/configuration.yml
+++ b/core/docker/data/conf/configuration.yml
@@ -8,6 +8,9 @@ server:
     - type: http
       port: 8081
 
+allocation:
+  strategy: ${env.ALLOCATION_STRATEGY!'CLUSTER'}
+
 cassandra:
   clusterName: ${env.CLUSTER_NAME!'cassieq'}
   keyspace: ${env.KEYSPACE!'cassieq'}

--- a/core/docker/data/conf/configuration.yml
+++ b/core/docker/data/conf/configuration.yml
@@ -75,7 +75,7 @@ logging:
   appenders:
     # Log warnings and errors to stderr
     - type: console
-      threshold: DEBUG
+      threshold: INFO
       target: stderr
       logFormat: "%d [%p] %marker [%mdc{corrId}] %logger %m%n"
 

--- a/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
+++ b/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
@@ -20,7 +20,7 @@ import io.paradoxical.cassieq.admin.AdminRoot;
 import io.paradoxical.cassieq.admin.resources.AdminPagesResource;
 import io.paradoxical.cassieq.admin.resources.api.v1.AccountResource;
 import io.paradoxical.cassieq.admin.resources.api.v1.PermissionsResource;
-import io.paradoxical.cassieq.auth.AuthLevelDynamicFeature;
+import io.paradoxical.cassieq.discoverable.auth.AuthLevelDynamicFeature;
 import io.paradoxical.cassieq.bundles.GuiceBundleProvider;
 import io.paradoxical.cassieq.commands.ConfigDumpCommand;
 import io.paradoxical.cassieq.configurations.LogMapping;

--- a/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
+++ b/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
@@ -109,8 +109,6 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
 
         run.add(this::configureLogging);
 
-        run.add(this::configureAuth);
-
         run.add(this::configureAdmin);
 
         run.stream().forEach(configFunction -> configFunction.accept(config, env));
@@ -154,10 +152,6 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
         swagConfig.setBasePath("/admin");
 
         resourceConfig.register(new SwaggerApiResource(swagConfig));
-    }
-
-    private void configureAuth(final ServiceConfiguration serviceConfiguration, final Environment environment) {
-        environment.jersey().register(AuthLevelDynamicFeature.class);
     }
 
     private void configureFilters(final ServiceConfiguration serviceConfiguration, final Environment environment) {

--- a/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
+++ b/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
@@ -49,7 +49,7 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
     @Getter
     private final GuiceBundleProvider guiceBundleProvider;
 
-    private Environment env;
+    protected Environment env;
 
     public ServiceApplication(final GuiceBundleProvider guiceBundleProvider) {
         this.guiceBundleProvider = guiceBundleProvider;
@@ -114,19 +114,6 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
         run.add(this::configureAdmin);
 
         run.stream().forEach(configFunction -> configFunction.accept(config, env));
-    }
-
-    public void stop() {
-        try {
-            logger.info("Stopping!");
-
-            env.getApplicationContext().getServer().stop();
-
-            logger.info("Stopped");
-        }
-        catch (Exception ex) {
-            logger.error(ex, "Unclean stop occurred!");
-        }
     }
 
     private void configureAdmin(final ServiceConfiguration serviceConfiguration, final Environment environment) {

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/AccountResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/AccountResource.java
@@ -3,17 +3,23 @@ package io.paradoxical.cassieq.admin.resources.api.v1;
 import com.codahale.metrics.annotation.Timed;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.paradoxical.cassieq.dataAccess.interfaces.AccountRepository;
-import io.paradoxical.cassieq.resources.api.BaseResource;
 import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
+import io.paradoxical.cassieq.model.accounts.AccountKey;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.resources.api.BaseResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import javax.annotation.Nullable;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -21,6 +27,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 @Path("/api/v1/accounts/")
@@ -30,10 +39,14 @@ public class AccountResource extends BaseResource {
 
     private static final Logger logger = LoggerFactory.getLogger(AccountResource.class);
     private final DataContextFactory dataContextFactory;
+    private final SecureRandom secureRandom;
 
     @Inject
-    public AccountResource(DataContextFactory dataContextFactory) {
+    public AccountResource(
+            DataContextFactory dataContextFactory,
+            SecureRandom secureRandom) {
         this.dataContextFactory = dataContextFactory;
+        this.secureRandom = secureRandom;
     }
 
     @POST
@@ -48,15 +61,37 @@ public class AccountResource extends BaseResource {
 
             final Optional<AccountDefinition> accountCreated = accountRepository.createAccount(accountName);
 
-            if(accountCreated.isPresent()){
+            if (accountCreated.isPresent()) {
                 return Response.status(Response.Status.CREATED).entity(accountCreated.get()).build();
             }
 
             return Response.status(Response.Status.CONFLICT).build();
         }
         catch (Exception e) {
-            logger.error(e, "Error");
-            return buildErrorResponse("CreateQueue", null, e);
+            logger.with(accountName).error(e, "Error creating account");
+
+            return buildErrorResponse("CreateAccount", null, e);
+        }
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get Accounts")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
+                            @ApiResponse(code = 500, message = "Server Error") })
+    public Response getAccount() {
+
+        try {
+            final AccountRepository accountRepository = dataContextFactory.getAccountRepository();
+
+            final List<AccountDefinition> accounts = accountRepository.getAllAccounts();
+
+            return Response.ok(accounts).build();
+        }
+        catch (Exception e) {
+            logger.error(e, "Error getting accounts");
+
+            return buildErrorResponse("ListAccount", null, e);
         }
     }
 
@@ -74,15 +109,103 @@ public class AccountResource extends BaseResource {
 
             final Optional<AccountDefinition> account = accountRepository.getAccount(accountName);
 
-            if(!account.isPresent()){
+            if (!account.isPresent()) {
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
 
             return Response.ok(account.get()).build();
         }
         catch (Exception e) {
-            logger.error(e, "Error");
-            return buildErrorResponse("CreateQueue", null, e);
+            logger.with("account-name", accountName).error(e, "Error getting account");
+
+            return buildErrorResponse("GetAccount", null, e);
         }
     }
+
+    @DELETE
+    @Timed
+    @Path("/{accountName}/keys/{keyName}")
+    @ApiOperation(value = "Delete Account Key")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
+                            @ApiResponse(code = 500, message = "Server Error") })
+    public Response deleteAccountKey(@PathParam("accountName") AccountName accountName, @PathParam("keyName") String keyName) {
+        try {
+            final AccountRepository accountRepository = dataContextFactory.getAccountRepository();
+
+            final Optional<AccountDefinition> account = accountRepository.getAccount(accountName);
+
+            if (!account.isPresent()) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            final AccountDefinition accountDefinition = account.get();
+
+            final HashMap<String, AccountKey> prunedKeys = new HashMap<>(accountDefinition.getKeys());
+
+            prunedKeys.remove(keyName);
+
+            accountDefinition.setKeys(ImmutableMap.copyOf(prunedKeys));
+
+            accountRepository.updateAccount(accountDefinition);
+
+            return Response.ok(accountDefinition).build();
+
+        }
+        catch (Exception e) {
+            logger.with("account-name", accountName)
+                  .with("key-name", keyName)
+                  .error(e, "Error getting account");
+
+            return buildErrorResponse("RemoveAccountKey", null, e);
+        }
+    }
+
+    @POST
+    @Timed
+    @Path("/{accountName}/keys/{keyName}")
+    @ApiOperation(value = "Delete Account Key")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
+                            @ApiResponse(code = 500, message = "Server Error") })
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Response addNewKey(@PathParam("accountName") AccountName accountName,
+                              @PathParam("keyName") String keyName,
+                              @Nullable String base64KeyBody) {
+        try {
+            final AccountRepository accountRepository = dataContextFactory.getAccountRepository();
+
+            final Optional<AccountDefinition> account = accountRepository.getAccount(accountName);
+
+            if (!account.isPresent()) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            final AccountDefinition accountDefinition = account.get();
+
+            if(accountDefinition.getKeys().containsKey(keyName)){
+                return buildConflictResponse("Key " + keyName + " already exists");
+            }
+
+            final HashMap<String, AccountKey> prunedKeys = new HashMap<>(accountDefinition.getKeys());
+
+            AccountKey key = Strings.isNullOrEmpty(base64KeyBody) ? AccountKey.random(secureRandom) : AccountKey.valueOf(base64KeyBody);
+
+            prunedKeys.put(keyName, key);
+
+            accountDefinition.setKeys(ImmutableMap.copyOf(prunedKeys));
+
+            accountRepository.updateAccount(accountDefinition);
+
+            return Response.ok().build();
+
+        }
+        catch (Exception e) {
+            logger.with("account-name", accountName)
+                  .with("key-name", keyName)
+                  .error(e, "Error creating account key");
+
+            return buildErrorResponse("AddAccountKey", null, e);
+        }
+    }
+
+
 }

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/AccountResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/AccountResource.java
@@ -11,6 +11,8 @@ import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.accounts.KeyName;
+import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
 import io.paradoxical.cassieq.resources.api.BaseResource;
 import io.paradoxical.cassieq.workers.QueueDeleter;
 import io.swagger.annotations.Api;
@@ -28,11 +30,14 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static java.util.stream.Collectors.toList;
 
 @Path("/api/v1/accounts/")
 @Api(value = "/api/v1/accounts/", description = "Account api", tags = "accounts")
@@ -135,7 +140,7 @@ public class AccountResource extends BaseResource {
     @ApiOperation(value = "Delete Account Key")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
                             @ApiResponse(code = 500, message = "Server Error") })
-    public Response deleteAccountKey(@PathParam("accountName") AccountName accountName, @PathParam("keyName") String keyName) {
+    public Response deleteAccountKey(@PathParam("accountName") AccountName accountName, @PathParam("keyName") KeyName keyName) {
         try {
             final AccountRepository accountRepository = dataContextFactory.getAccountRepository();
 
@@ -147,7 +152,7 @@ public class AccountResource extends BaseResource {
 
             final AccountDefinition accountDefinition = account.get();
 
-            final HashMap<String, AccountKey> prunedKeys = new HashMap<>(accountDefinition.getKeys());
+            final HashMap<KeyName, AccountKey> prunedKeys = new HashMap<>(accountDefinition.getKeys());
 
             prunedKeys.remove(keyName);
 
@@ -176,7 +181,7 @@ public class AccountResource extends BaseResource {
     @Consumes(MediaType.TEXT_PLAIN)
     public Response addNewKey(
             @PathParam("accountName") AccountName accountName,
-            @PathParam("keyName") String keyName) {
+            @PathParam("keyName") KeyName keyName) {
         try {
             final AccountRepository accountRepository = dataContextFactory.getAccountRepository();
 
@@ -192,7 +197,7 @@ public class AccountResource extends BaseResource {
                 return buildConflictResponse("Key " + keyName + " already exists");
             }
 
-            final HashMap<String, AccountKey> prunedKeys = new HashMap<>(accountDefinition.getKeys());
+            final HashMap<KeyName, AccountKey> prunedKeys = new HashMap<>(accountDefinition.getKeys());
 
             final AccountKey key = AccountKey.random(secureRandom);
 

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.paradoxical.cassieq.auth.SignedUrlParameterNames;
 import io.paradoxical.cassieq.factories.DataContextFactory;
+import io.paradoxical.cassieq.model.QueryAuthUrlResult;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
 import io.paradoxical.cassieq.model.accounts.AccountName;
@@ -95,8 +96,6 @@ public class PermissionsResource extends BaseResource {
                                                          .sig(computedSignature)
                                                          .build();
 
-        return Response.ok(new Object(){
-            public String queryUrl = queryParam;
-        }).build();
+        return Response.ok(new QueryAuthUrlResult(queryParam)).build();
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
@@ -5,7 +5,7 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import io.paradoxical.cassieq.auth.SignedUrlParameterNames;
+import io.paradoxical.cassieq.discoverable.auth.SignedUrlParameterNames;
 import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.model.QueryAuthUrlResult;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
@@ -89,7 +89,7 @@ public class PermissionsResource extends BaseResource {
 
         final AccountKey key = keys.get(request.getKeyName());
 
-        final String computedSignature = signedUrlParameterGenerator.computeSignature(MacProviders.Hmac256(key));
+        final String computedSignature = signedUrlParameterGenerator.computeSignature(MacProviders.HmacSha256(key));
 
         final String queryParam = SignedUrlParameterNames.builder()
                                                          .auth(authorizationLevels)

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
@@ -13,6 +13,7 @@ import io.paradoxical.cassieq.model.accounts.AccountKey;
 import io.paradoxical.cassieq.model.accounts.GetAuthQueryParamsRequest;
 import io.paradoxical.cassieq.model.accounts.KeyName;
 import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
+import io.paradoxical.cassieq.model.auth.MacProviders;
 import io.paradoxical.cassieq.model.auth.SignedUrlParameterGenerator;
 import io.paradoxical.cassieq.resources.api.BaseResource;
 import io.swagger.annotations.Api;
@@ -86,7 +87,9 @@ public class PermissionsResource extends BaseResource {
 
         final SignedUrlParameterGenerator signedUrlParameterGenerator = new SignedUrlParameterGenerator(request.getAccountName(), authorizationLevels);
 
-        final String computedSignature = signedUrlParameterGenerator.computeSignature(keys.get(request.getKeyName()));
+        final AccountKey key = keys.get(request.getKeyName());
+
+        final String computedSignature = signedUrlParameterGenerator.computeSignature(MacProviders.Hmac256(key));
 
         final String queryParam = SignedUrlParameterNames.builder()
                                                          .auth(authorizationLevels)

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
@@ -1,0 +1,102 @@
+package io.paradoxical.cassieq.admin.resources.api.v1;
+
+import com.codahale.metrics.annotation.Timed;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.paradoxical.cassieq.auth.SignedUrlParameterNames;
+import io.paradoxical.cassieq.factories.DataContextFactory;
+import io.paradoxical.cassieq.model.accounts.AccountDefinition;
+import io.paradoxical.cassieq.model.accounts.AccountKey;
+import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.accounts.KeyName;
+import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
+import io.paradoxical.cassieq.model.auth.SignedUrlParameterGenerator;
+import io.paradoxical.cassieq.resources.api.BaseResource;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
+
+@Path("/api/v1/permissions/")
+@Api(value = "/api/v1/permissions/", description = "Permissions api", tags = "permissions")
+@Produces(MediaType.APPLICATION_JSON)
+public class PermissionsResource extends BaseResource {
+
+    private static final Logger logger = LoggerFactory.getLogger(PermissionsResource.class);
+    private final DataContextFactory dataContextFactory;
+
+    @Inject
+    public PermissionsResource(
+            DataContextFactory dataContextFactory) {
+        this.dataContextFactory = dataContextFactory;
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "List available permissions")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
+                            @ApiResponse(code = 500, message = "Server Error") })
+    public Response listPermissions() {
+        final List<Object> permissions = Arrays.stream(AuthorizationLevel.values()).map(a -> new Object() {
+            public String level = a.name();
+            public String shortForm = a.getShortForm();
+        }).collect(toList());
+
+        return Response.ok(permissions).build();
+    }
+
+    @POST
+    @Timed
+    @ApiOperation(value = "Generator auth url")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
+                            @ApiResponse(code = 500, message = "Server Error") })
+    public Response generateAuthUrl(
+            @QueryParam("accountName") AccountName accountName,
+            @QueryParam("keyName") KeyName keyName,
+            @QueryParam("shortForm") String shortForm) throws NoSuchAlgorithmException, InvalidKeyException {
+        final Optional<AccountDefinition> accountDefinition = dataContextFactory.getAccountRepository().getAccount(accountName);
+
+        if (!accountDefinition.isPresent()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        final EnumSet<AuthorizationLevel> authorizationLevels = AuthorizationLevel.parse(shortForm);
+
+        final ImmutableMap<KeyName, AccountKey> keys = accountDefinition.get().getKeys();
+
+        if (!keys.containsKey(keyName)) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        final SignedUrlParameterGenerator signedUrlParameterGenerator = new SignedUrlParameterGenerator(accountName, authorizationLevels);
+
+        final String computedSignature = signedUrlParameterGenerator.computeSignature(keys.get(keyName));
+
+        final String queryParam = SignedUrlParameterNames.builder()
+                                                         .auth(authorizationLevels)
+                                                         .sig(computedSignature)
+                                                         .build();
+
+        return Response.ok(new Object(){
+            public String queryUrl = queryParam;
+        }).build();
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/PermissionsResource.java
@@ -66,7 +66,7 @@ public class PermissionsResource extends BaseResource {
 
     @POST
     @Timed
-    @ApiOperation(value = "Generator auth url")
+    @ApiOperation(value = "Generate auth url")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
                             @ApiResponse(code = 500, message = "Server Error") })
     public Response generateAuthUrl(

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/QueueDebugResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/QueueDebugResource.java
@@ -1,7 +1,7 @@
 package io.paradoxical.cassieq.admin.resources.api.v1;
 
 import com.google.inject.Inject;
-import io.paradoxical.cassieq.auth.AccountAuth;
+import io.paradoxical.cassieq.discoverable.auth.AccountAuth;
 import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
 import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
 import io.paradoxical.cassieq.resources.api.BaseQueueResource;

--- a/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/QueueDebugResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/resources/api/v1/QueueDebugResource.java
@@ -1,6 +1,7 @@
 package io.paradoxical.cassieq.admin.resources.api.v1;
 
 import com.google.inject.Inject;
+import io.paradoxical.cassieq.auth.AccountAuth;
 import io.paradoxical.cassieq.dataAccess.interfaces.MonotonicRepository;
 import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
 import io.paradoxical.cassieq.resources.api.BaseQueueResource;

--- a/core/src/main/java/io/paradoxical/cassieq/admin/tasks/AccountTask.java
+++ b/core/src/main/java/io/paradoxical/cassieq/admin/tasks/AccountTask.java
@@ -1,6 +1,5 @@
 package io.paradoxical.cassieq.admin.tasks;
 
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -9,12 +8,11 @@ import io.paradoxical.cassieq.dataAccess.interfaces.AccountRepository;
 import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
+import io.paradoxical.cassieq.model.accounts.KeyName;
 
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.stream.Collectors.toList;
 
 @SuppressWarnings("unused")
 public class AccountTask extends Task {
@@ -35,7 +33,7 @@ public class AccountTask extends Task {
 
         allAccounts.forEach(account -> {
 
-            final ImmutableSet<Map.Entry<String, AccountKey>> keys = account.getKeys().entrySet();
+            final ImmutableSet<Map.Entry<KeyName, AccountKey>> keys = account.getKeys().entrySet();
 
             output.format("account: %s\n", account.getAccountName().get());
             keys.forEach(key -> output.format("    key: %s  value: %s\n", key.getKey(), key.getValue().get()));

--- a/core/src/main/java/io/paradoxical/cassieq/auth/AccountAuth.java
+++ b/core/src/main/java/io/paradoxical/cassieq/auth/AccountAuth.java
@@ -1,0 +1,9 @@
+package io.paradoxical.cassieq.auth;
+
+import javax.ws.rs.NameBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AccountAuth {}

--- a/core/src/main/java/io/paradoxical/cassieq/auth/AuthLevelDynamicFeature.java
+++ b/core/src/main/java/io/paradoxical/cassieq/auth/AuthLevelDynamicFeature.java
@@ -17,12 +17,14 @@ import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
+@Provider
 public class AuthLevelDynamicFeature implements DynamicFeature {
     private static final Logger logger = getLogger(AuthLevelDynamicFeature.class);
 

--- a/core/src/main/java/io/paradoxical/cassieq/auth/AuthLevelDynamicFeature.java
+++ b/core/src/main/java/io/paradoxical/cassieq/auth/AuthLevelDynamicFeature.java
@@ -1,0 +1,83 @@
+package io.paradoxical.cassieq.auth;
+
+import com.godaddy.logging.Logger;
+import io.dropwizard.auth.Authenticator;
+import io.paradoxical.cassieq.discoverable.resources.api.v1.AuthLevelRequired;
+import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
+import io.paradoxical.cassieq.model.auth.AuthorizedRequestCredentials;
+import org.glassfish.jersey.server.model.AnnotatedMethod;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static com.godaddy.logging.LoggerFactory.getLogger;
+
+public class AuthLevelDynamicFeature implements DynamicFeature {
+    private static final Logger logger = getLogger(AuthLevelDynamicFeature.class);
+
+    private final Authenticator<AuthorizedRequestCredentials, AccountPrincipal> authenticator;
+
+    @Inject
+    public AuthLevelDynamicFeature(Authenticator<AuthorizedRequestCredentials, AccountPrincipal> authenticator) {
+        this.authenticator = authenticator;
+    }
+
+    @Override
+    public void configure(final ResourceInfo resourceInfo, final FeatureContext context) {
+        final AnnotatedMethod am = new AnnotatedMethod(resourceInfo.getResourceMethod());
+
+        /**
+         * Register a custom filter for each method based on what the filter asked its auth level to be
+         */
+        if (am.isAnnotationPresent(AuthLevelRequired.class)) {
+            logger.with("method", resourceInfo.getResourceMethod().getName())
+                  .with("resource", resourceInfo.getResourceClass().getSimpleName())
+                  .info("Registering auth filter");
+
+            final EnumSet<AuthorizationLevel> requiredLevels = EnumSet.copyOf(Arrays.asList(am.getAnnotation(AuthLevelRequired.class).levels()));
+
+            context.register(getAuthFilter(requiredLevels));
+
+            context.register(new AuthorizationFilter());
+        }
+    }
+
+    public SignedRequestAuthenticationFilter<AccountPrincipal> getAuthFilter(EnumSet<AuthorizationLevel> allowedLevels) {
+        return SignedRequestAuthenticationFilter.<AccountPrincipal>builder()
+                .accountNamePathParameter("accountName")
+                .setAuthenticator(authenticator)
+                .setPrefix("Signed")
+                .setAuthorizer((principal, role) -> {
+                    final EnumSet<AuthorizationLevel> claimedLevels = principal.getAuthorizationLevels();
+
+                    return allowedLevels.stream().anyMatch(claimedLevels::contains);
+                })
+                .setUnauthorizedHandler((prefix, realm) -> Response.status(Response.Status.UNAUTHORIZED).build())
+                .buildAuthFilter();
+    }
+
+    @Priority(Priorities.AUTHORIZATION) // authorization filter - should go after any authentication filters
+    private static class AuthorizationFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(final ContainerRequestContext requestContext) throws IOException {
+            /**
+             * Authenticated but not authorized
+             */
+            if (!requestContext.getSecurityContext().isUserInRole(null)) {
+                throw new ForbiddenException();
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/auth/AuthLevelDynamicFeature.java
+++ b/core/src/main/java/io/paradoxical/cassieq/auth/AuthLevelDynamicFeature.java
@@ -58,7 +58,7 @@ public class AuthLevelDynamicFeature implements DynamicFeature {
                 .accountNamePathParameter("accountName")
                 .setAuthenticator(authenticator)
                 .setPrefix("Signed")
-                .setAuthorizer((principal, role) -> {
+                .setAuthorizer((principal, _ignore) -> {
                     final EnumSet<AuthorizationLevel> claimedLevels = principal.getAuthorizationLevels();
 
                     return allowedLevels.stream().anyMatch(claimedLevels::contains);

--- a/core/src/main/java/io/paradoxical/cassieq/auth/SignedRequestAuthenticationFilter.java
+++ b/core/src/main/java/io/paradoxical/cassieq/auth/SignedRequestAuthenticationFilter.java
@@ -33,13 +33,15 @@ import static com.godaddy.logging.LoggerFactory.getLogger;
 @AccountAuth
 @Priority(Priorities.AUTHENTICATION)
 @Builder(builderClassName = "Builder")
-public class SignedRequestAuthFilter<TPrincipal extends Principal> extends AuthFilter<AuthorizedRequestCredentials, TPrincipal> {
-    private static final Logger logger = getLogger(SignedRequestAuthFilter.class);
+public class SignedRequestAuthenticationFilter<TPrincipal extends Principal> extends AuthFilter<AuthorizedRequestCredentials, TPrincipal> {
+    private static final Logger logger = getLogger(SignedRequestAuthenticationFilter.class);
 
     private final String accountNamePathParameter;
     private final String keyAuthPrefix;
 
-    public SignedRequestAuthFilter(String accountNamePathParameter, final String keyAuthPrefix) {
+    public SignedRequestAuthenticationFilter(
+            String accountNamePathParameter,
+            final String keyAuthPrefix) {
         this.accountNamePathParameter = accountNamePathParameter;
         this.keyAuthPrefix = keyAuthPrefix;
     }
@@ -57,13 +59,12 @@ public class SignedRequestAuthFilter<TPrincipal extends Principal> extends AuthF
 
                 final SignedUrlParameters signedUrlParameters = parseSignedUrlParameters(requestContext, accountName);
 
-                if(headerRequestParameters == null && signedUrlParameters == null){
+                if (headerRequestParameters == null && signedUrlParameters == null) {
                     throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));
                 }
 
                 // the request params we'll use to auth, with priority from header vs query param
                 final RequestParameters requestParameters = MoreObjects.firstNonNull(headerRequestParameters, signedUrlParameters);
-
 
                 final AuthorizedRequestCredentials credentials =
                         AuthorizedRequestCredentials.builder()
@@ -144,6 +145,7 @@ public class SignedRequestAuthFilter<TPrincipal extends Principal> extends AuthF
 
     private boolean setPrincipal(final ContainerRequestContext requestContext, final AuthorizedRequestCredentials credentials) {
         try {
+
             final Optional<TPrincipal> optionalPrincipal = authenticator.authenticate(credentials);
             if (optionalPrincipal.isPresent()) {
 
@@ -162,7 +164,7 @@ public class SignedRequestAuthFilter<TPrincipal extends Principal> extends AuthF
         return false;
     }
 
-    public static class Builder<TPrincipal extends Principal> extends AuthFilterBuilder<AuthorizedRequestCredentials, TPrincipal, SignedRequestAuthFilter<TPrincipal>> {
+    public static class Builder<TPrincipal extends Principal> extends AuthFilterBuilder<AuthorizedRequestCredentials, TPrincipal, SignedRequestAuthenticationFilter<TPrincipal>> {
 
         public Builder() {
             setPrefix("Signed");
@@ -170,15 +172,15 @@ public class SignedRequestAuthFilter<TPrincipal extends Principal> extends AuthF
         }
 
         @Override
-        protected SignedRequestAuthFilter<TPrincipal> newInstance() {
-            final SignedRequestAuthFilter<TPrincipal> filter = new SignedRequestAuthFilter<>(
+        protected SignedRequestAuthenticationFilter<TPrincipal> newInstance() {
+            final SignedRequestAuthenticationFilter<TPrincipal> filter = new SignedRequestAuthenticationFilter<>(
                     Strings.isNullOrEmpty(accountNamePathParameter) ? "accountName" : accountNamePathParameter,
                     Strings.isNullOrEmpty(keyAuthPrefix) ? "Key" : keyAuthPrefix);
 
             return filter;
         }
 
-        public SignedRequestAuthFilter<TPrincipal> build() {
+        public SignedRequestAuthenticationFilter<TPrincipal> build() {
             return buildAuthFilter();
         }
     }

--- a/core/src/main/java/io/paradoxical/cassieq/auth/SignedRequestAuthenticator.java
+++ b/core/src/main/java/io/paradoxical/cassieq/auth/SignedRequestAuthenticator.java
@@ -11,9 +11,6 @@ import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.auth.AuthorizedRequestCredentials;
 import io.paradoxical.cassieq.model.auth.RequestParameters;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
 public class SignedRequestAuthenticator implements Authenticator<AuthorizedRequestCredentials, AccountPrincipal> {
@@ -34,15 +31,16 @@ public class SignedRequestAuthenticator implements Authenticator<AuthorizedReque
 
         final java.util.Optional<AccountDefinition> account = accountRepository.getAccount(requestParameters.getAccountName());
 
-        if(account.isPresent()){
+        if (account.isPresent()) {
             try {
-                if(credentials.verify(account.get().getKeys().values())){
+                if (credentials.verify(account.get().getKeys().values())) {
 
                     return Optional.of(new AccountPrincipal(requestParameters.getAccountName(), requestParameters.getAuthorizationLevels()));
                 }
             }
             catch (Exception e) {
                 logger.error(e, "Credential Verification Failed");
+
                 throw new AuthenticationException("Credential Verification Failed", e);
             }
         }

--- a/core/src/main/java/io/paradoxical/cassieq/auth/SignedRequestAuthenticator.java
+++ b/core/src/main/java/io/paradoxical/cassieq/auth/SignedRequestAuthenticator.java
@@ -34,7 +34,6 @@ public class SignedRequestAuthenticator implements Authenticator<AuthorizedReque
         if (account.isPresent()) {
             try {
                 if (credentials.verify(account.get().getKeys().values())) {
-
                     return Optional.of(new AccountPrincipal(requestParameters.getAccountName(), requestParameters.getAuthorizationLevels()));
                 }
             }

--- a/core/src/main/java/io/paradoxical/cassieq/auth/SignedUrlParameterNames.java
+++ b/core/src/main/java/io/paradoxical/cassieq/auth/SignedUrlParameterNames.java
@@ -1,7 +1,13 @@
 package io.paradoxical.cassieq.auth;
 
+import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
 import lombok.Getter;
 import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
 
 public enum SignedUrlParameterNames {
     AuthorizationLevels("auth"),
@@ -12,5 +18,34 @@ public enum SignedUrlParameterNames {
 
     SignedUrlParameterNames(@NonNull final String parameterName) {
         this.parameterName = parameterName;
+    }
+
+    public static SignedUrlParameterBuilder builder(){
+        return new SignedUrlParameterBuilder();
+    }
+
+    public static class SignedUrlParameterBuilder{
+        private List<String> queryParamBuilder = new ArrayList<>();
+
+        public SignedUrlParameterBuilder sig(String signature){
+            queryParamBuilder.add(Signature.getParameterName() + "=" + signature);
+
+            return this;
+        }
+
+        public SignedUrlParameterBuilder auth(EnumSet<AuthorizationLevel> levels){
+            final String shortForm = levels.stream()
+                                           .reduce(StringUtils.EMPTY,
+                                                   (acc, level) -> acc + level.getShortForm(),
+                                                   (acc1, acc2) -> acc1 + acc2);
+
+            queryParamBuilder.add(AuthorizationLevels.getParameterName() + "=" + shortForm);
+
+            return this;
+        }
+
+        public String build(){
+            return String.join("&", queryParamBuilder);
+        }
     }
 }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/AccountRepositoryImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/AccountRepositoryImpl.java
@@ -15,6 +15,7 @@ import io.paradoxical.cassieq.dataAccess.interfaces.AccountRepository;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.accounts.KeyName;
 import io.paradoxical.cassieq.model.accounts.WellKnownKeyNames;
 
 import java.security.SecureRandom;
@@ -47,14 +48,14 @@ public class AccountRepositoryImpl extends RepositoryBase implements AccountRepo
         AccountKey primaryKey = AccountKey.random(secureRandom);
         AccountKey secondaryKey = AccountKey.random(secureRandom);
 
-        final ImmutableMap<String, String> keys = ImmutableMap.of(
-                WellKnownKeyNames.Primary.getKeyName(), primaryKey.get(),
-                WellKnownKeyNames.Secondary.getKeyName(), secondaryKey.get());
+        final ImmutableMap<KeyName, AccountKey> keys = ImmutableMap.of(
+                WellKnownKeyNames.Primary.getKeyName(), primaryKey,
+                WellKnownKeyNames.Secondary.getKeyName(), secondaryKey);
 
         final Insert createNewAccount = insertInto(Tables.Account.TABLE_NAME)
                 .ifNotExists()
                 .value(Tables.Account.ACCOUNT_NAME, accountName.get())
-                .value(Tables.Account.KEYS, keys);
+                .value(Tables.Account.KEYS, saveableMap(keys));
 
         final ResultSet createAccountResult = session.execute(createNewAccount);
 
@@ -112,10 +113,10 @@ public class AccountRepositoryImpl extends RepositoryBase implements AccountRepo
         }
     }
 
-    private ImmutableMap<String, String> saveableMap(final ImmutableMap<String, AccountKey> keys) {
+    private ImmutableMap<String, String> saveableMap(final ImmutableMap<KeyName, AccountKey> keys) {
         final HashMap<String, String> target = new HashMap<>();
 
-        keys.keySet().forEach(entry -> target.put(entry, keys.get(entry).get()));
+        keys.keySet().forEach(entry -> target.put(entry.get(), keys.get(entry).get()));
 
         return ImmutableMap.copyOf(target);
     }

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageDeletorJobProcessorImpl.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/MessageDeletorJobProcessorImpl.java
@@ -42,7 +42,7 @@ public class MessageDeletorJobProcessorImpl implements MessageDeleterJobProcesso
     private final PointerRepository pointerRepository;
     private final MonotonicRepository monotonicRepository;
 
-    private static final Logger logger = getLogger(MessageDeletorJobProcessorImpl.class);
+    private Logger logger = getLogger(MessageDeletorJobProcessorImpl.class);
     private final QueueRepository queueRepository;
 
     @Inject
@@ -60,6 +60,8 @@ public class MessageDeletorJobProcessorImpl implements MessageDeleterJobProcesso
         queueRepository = dataContextFactory.forAccount(job.getAccountName());
         pointerRepository = dataContextFactory.getPointerRepository(queueId);
         monotonicRepository = dataContextFactory.getMonotonicRepository(queueId);
+
+        logger = logger.with(job);
     }
 
     /**
@@ -72,15 +74,27 @@ public class MessageDeletorJobProcessorImpl implements MessageDeleterJobProcesso
 
             final MessagePointer endPointer = monotonicRepository.getCurrent();
 
+            logger.debug("Starting deletion job");
+
             delete(startPointer, endPointer);
+
+            logger.success("Deleted all messages!");
 
             monotonicRepository.deleteAll();
 
+            logger.success("Deleted all monotons!");
+
             pointerRepository.deleteAll();
+
+            logger.success("Deleted all pointers!");
 
             queueRepository.deleteQueueStats(job.getQueueStatsId());
 
+            logger.success("Deleted all stats!");
+
             complete();
+
+            logger.success("Complete");
         }
     }
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/AccountRepository.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/interfaces/AccountRepository.java
@@ -15,4 +15,6 @@ public interface AccountRepository {
     List<AccountDefinition> getAllAccounts();
 
     void deleteAccount(AccountName accountName);
+
+    void updateAccount(AccountDefinition accountDefinition);
 }

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AccountAuth.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AccountAuth.java
@@ -1,4 +1,4 @@
-package io.paradoxical.cassieq.auth;
+package io.paradoxical.cassieq.discoverable.auth;
 
 import javax.ws.rs.NameBinding;
 import java.lang.annotation.Retention;

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AccountPrincipal.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AccountPrincipal.java
@@ -1,4 +1,4 @@
-package io.paradoxical.cassieq.auth;
+package io.paradoxical.cassieq.discoverable.auth;
 
 import io.paradoxical.cassieq.model.accounts.AccountName;
 import io.paradoxical.cassieq.model.auth.AuthorizationLevel;

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AccountSecurityContext.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AccountSecurityContext.java
@@ -1,4 +1,4 @@
-package io.paradoxical.cassieq.auth;
+package io.paradoxical.cassieq.discoverable.auth;
 
 import io.dropwizard.auth.Authorizer;
 

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AuthLevelDynamicFeature.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AuthLevelDynamicFeature.java
@@ -37,17 +37,17 @@ public class AuthLevelDynamicFeature implements DynamicFeature {
 
     @Override
     public void configure(final ResourceInfo resourceInfo, final FeatureContext context) {
-        final AnnotatedMethod am = new AnnotatedMethod(resourceInfo.getResourceMethod());
+        final AnnotatedMethod annotatedMethod = new AnnotatedMethod(resourceInfo.getResourceMethod());
 
         /**
          * Register a custom filter for each method based on what the filter asked its auth level to be
          */
-        if (am.isAnnotationPresent(AuthLevelRequired.class)) {
+        if (annotatedMethod.isAnnotationPresent(AuthLevelRequired.class)) {
             logger.with("method", resourceInfo.getResourceMethod().getName())
                   .with("resource", resourceInfo.getResourceClass().getSimpleName())
                   .info("Registering auth filter");
 
-            final EnumSet<AuthorizationLevel> requiredLevels = EnumSet.copyOf(Arrays.asList(am.getAnnotation(AuthLevelRequired.class).levels()));
+            final EnumSet<AuthorizationLevel> requiredLevels = EnumSet.copyOf(Arrays.asList(annotatedMethod.getAnnotation(AuthLevelRequired.class).level()));
 
             context.register(getAuthFilter(requiredLevels));
 
@@ -55,7 +55,7 @@ public class AuthLevelDynamicFeature implements DynamicFeature {
         }
     }
 
-    public SignedRequestAuthenticationFilter<AccountPrincipal> getAuthFilter(EnumSet<AuthorizationLevel> allowedLevels) {
+    public SignedRequestAuthenticationFilter<AccountPrincipal> getAuthFilter(final EnumSet<AuthorizationLevel> allowedLevels) {
         return SignedRequestAuthenticationFilter.<AccountPrincipal>builder()
                 .accountNamePathParameter("accountName")
                 .setAuthenticator(authenticator)

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AuthLevelDynamicFeature.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/AuthLevelDynamicFeature.java
@@ -1,4 +1,4 @@
-package io.paradoxical.cassieq.auth;
+package io.paradoxical.cassieq.discoverable.auth;
 
 import com.godaddy.logging.Logger;
 import io.dropwizard.auth.Authenticator;

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedRequestAuthenticationFilter.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedRequestAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package io.paradoxical.cassieq.auth;
+package io.paradoxical.cassieq.discoverable.auth;
 
 import com.godaddy.logging.Logger;
 import com.google.common.base.MoreObjects;

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedRequestAuthenticator.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedRequestAuthenticator.java
@@ -1,4 +1,4 @@
-package io.paradoxical.cassieq.auth;
+package io.paradoxical.cassieq.discoverable.auth;
 
 import com.godaddy.logging.Logger;
 import com.google.common.base.Optional;

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedUrlParameterNames.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedUrlParameterNames.java
@@ -1,4 +1,4 @@
-package io.paradoxical.cassieq.auth;
+package io.paradoxical.cassieq.discoverable.auth;
 
 import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
 import lombok.Getter;

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/AuthLevelRequired.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/AuthLevelRequired.java
@@ -12,5 +12,5 @@ import java.lang.annotation.Target;
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthLevelRequired {
-    AuthorizationLevel[] levels();
+    AuthorizationLevel level();
 }

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/AuthLevelRequired.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/AuthLevelRequired.java
@@ -1,0 +1,16 @@
+package io.paradoxical.cassieq.discoverable.resources.api.v1;
+
+import com.google.inject.BindingAnnotation;
+import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@BindingAnnotation
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthLevelRequired {
+    AuthorizationLevel[] levels();
+}

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/QueueResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/QueueResource.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import com.google.inject.Inject;
-import io.paradoxical.cassieq.auth.AccountAuth;
+import io.paradoxical.cassieq.discoverable.auth.AccountAuth;
 import io.paradoxical.cassieq.dataAccess.exceptions.ExistingMonotonFoundException;
 import io.paradoxical.cassieq.dataAccess.exceptions.QueueAlreadyDeletingException;
 import io.paradoxical.cassieq.factories.DataContextFactory;
@@ -37,7 +37,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/QueueResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/QueueResource.java
@@ -63,7 +63,7 @@ public class QueueResource extends BaseQueueResource {
 
     @GET
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.GetQueueInformation)
+    @AuthLevelRequired(level = AuthorizationLevel.GetQueueInformation)
     @ApiOperation(value = "Get all account queue definitions")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
                             @ApiResponse(code = 500, message = "Server Error") })
@@ -77,7 +77,7 @@ public class QueueResource extends BaseQueueResource {
     @GET
     @Path("/{queueName}")
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.GetQueueInformation)
+    @AuthLevelRequired(level = AuthorizationLevel.GetQueueInformation)
     @ApiOperation(value = "Get a queue definition")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
                             @ApiResponse(code = 404, message = "Queue doesn't exist"),
@@ -99,7 +99,7 @@ public class QueueResource extends BaseQueueResource {
     @GET
     @Path("/{queueName}/statistics")
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.GetQueueInformation)
+    @AuthLevelRequired(level = AuthorizationLevel.GetQueueInformation)
     @ApiOperation(value = "Get queue statistics")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
                             @ApiResponse(code = 404, message = "Queue doesn't exist"),
@@ -131,7 +131,7 @@ public class QueueResource extends BaseQueueResource {
 
     @POST
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.CreateQueue)
+    @AuthLevelRequired(level = AuthorizationLevel.CreateQueue)
     @ApiOperation(value = "Create Queue")
     @ApiResponses(value = { @ApiResponse(code = 201, message = "Created"),
                             @ApiResponse(code = 500, message = "Server Error") })
@@ -175,7 +175,7 @@ public class QueueResource extends BaseQueueResource {
     @DELETE
     @Path("/{queueName}")
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.DeleteQueue)
+    @AuthLevelRequired(level = AuthorizationLevel.DeleteQueue)
     @QueueTimer(actionName = "delete")
     @ApiOperation(value = "Delete queue")
     @ApiResponses(value = {
@@ -199,7 +199,7 @@ public class QueueResource extends BaseQueueResource {
     @GET
     @Path("/{queueName}/messages/next")
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.ReadMessage)
+    @AuthLevelRequired(level = AuthorizationLevel.ReadMessage)
     @QueueTimer(actionName = "read")
     @ApiOperation(value = "Get Message")
     @ApiResponses(value = {
@@ -255,7 +255,7 @@ public class QueueResource extends BaseQueueResource {
     @PUT
     @Path("/{queueName}/messages")
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.UpdateMessage)
+    @AuthLevelRequired(level = AuthorizationLevel.UpdateMessage)
     @QueueTimer(actionName = "update-message")
     @ApiOperation(value = "Update Message")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = UpdateMessageResponse.class),
@@ -290,7 +290,7 @@ public class QueueResource extends BaseQueueResource {
     @POST
     @Path("/{queueName}/messages")
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.PutMessage)
+    @AuthLevelRequired(level = AuthorizationLevel.PutMessage)
     @QueueTimer(actionName = "publish")
     @ApiOperation(value = "Put Message")
     @ApiResponses(value = { @ApiResponse(code = 201, message = "Message Added"),
@@ -336,7 +336,7 @@ public class QueueResource extends BaseQueueResource {
     @DELETE
     @Path("/{queueName}/messages")
     @Timed
-    @AuthLevelRequired(levels = AuthorizationLevel.AckMessage)
+    @AuthLevelRequired(level = AuthorizationLevel.AckMessage)
     @QueueTimer(actionName = "ack")
     @ApiOperation(value = "Ack Message")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/QueueResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/QueueResource.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import com.google.inject.Inject;
+import io.paradoxical.cassieq.auth.AccountAuth;
 import io.paradoxical.cassieq.dataAccess.exceptions.ExistingMonotonFoundException;
 import io.paradoxical.cassieq.dataAccess.exceptions.QueueAlreadyDeletingException;
 import io.paradoxical.cassieq.factories.DataContextFactory;
@@ -16,7 +17,6 @@ import io.paradoxical.cassieq.model.*;
 import io.paradoxical.cassieq.model.accounts.AccountName;
 import io.paradoxical.cassieq.resources.api.BaseQueueResource;
 import io.paradoxical.cassieq.workers.QueueDeleter;
-import io.paradoxical.cassieq.workers.repair.RepairWorkerManager;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -39,13 +39,13 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Optional;
 
+@AccountAuth
 @Path("/api/v1/accounts/{accountName}/queues")
 @Api(value = "/api/v1/accounts/{accountName}/queues", description = "Queue api", tags = "cassieq")
 @Produces(MediaType.APPLICATION_JSON)
 public class QueueResource extends BaseQueueResource {
 
     private static final Logger logger = LoggerFactory.getLogger(QueueResource.class);
-    private final RepairWorkerManager repairWorkerManager;
     private final QueueDeleter queueDeleter;
 
     @Inject
@@ -54,11 +54,9 @@ public class QueueResource extends BaseQueueResource {
             MessageRepoFactory messageRepoFactory,
             MonotonicRepoFactory monotonicRepoFactory,
             DataContextFactory dataContextFactory,
-            RepairWorkerManager repairWorkerManager,
             QueueDeleter.Factory queueDeleterFactory,
             @PathParam("accountName") AccountName accountName) {
         super(readerFactory, messageRepoFactory, monotonicRepoFactory, dataContextFactory.forAccount(accountName), accountName);
-        this.repairWorkerManager = repairWorkerManager;
         this.queueDeleter = queueDeleterFactory.create(accountName);
     }
 

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/QueueResource.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/resources/api/v1/QueueResource.java
@@ -15,6 +15,7 @@ import io.paradoxical.cassieq.factories.ReaderFactory;
 import io.paradoxical.cassieq.metrics.QueueTimer;
 import io.paradoxical.cassieq.model.*;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
 import io.paradoxical.cassieq.resources.api.BaseQueueResource;
 import io.paradoxical.cassieq.workers.QueueDeleter;
 import io.swagger.annotations.Api;
@@ -36,6 +37,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,6 +64,7 @@ public class QueueResource extends BaseQueueResource {
 
     @GET
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.GetQueueInformation)
     @ApiOperation(value = "Get all account queue definitions")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
                             @ApiResponse(code = 500, message = "Server Error") })
@@ -75,6 +78,7 @@ public class QueueResource extends BaseQueueResource {
     @GET
     @Path("/{queueName}")
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.GetQueueInformation)
     @ApiOperation(value = "Get a queue definition")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
                             @ApiResponse(code = 404, message = "Queue doesn't exist"),
@@ -96,6 +100,7 @@ public class QueueResource extends BaseQueueResource {
     @GET
     @Path("/{queueName}/statistics")
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.GetQueueInformation)
     @ApiOperation(value = "Get queue statistics")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
                             @ApiResponse(code = 404, message = "Queue doesn't exist"),
@@ -127,6 +132,7 @@ public class QueueResource extends BaseQueueResource {
 
     @POST
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.CreateQueue)
     @ApiOperation(value = "Create Queue")
     @ApiResponses(value = { @ApiResponse(code = 201, message = "Created"),
                             @ApiResponse(code = 500, message = "Server Error") })
@@ -170,6 +176,7 @@ public class QueueResource extends BaseQueueResource {
     @DELETE
     @Path("/{queueName}")
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.DeleteQueue)
     @QueueTimer(actionName = "delete")
     @ApiOperation(value = "Delete queue")
     @ApiResponses(value = {
@@ -193,6 +200,7 @@ public class QueueResource extends BaseQueueResource {
     @GET
     @Path("/{queueName}/messages/next")
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.ReadMessage)
     @QueueTimer(actionName = "read")
     @ApiOperation(value = "Get Message")
     @ApiResponses(value = {
@@ -248,6 +256,7 @@ public class QueueResource extends BaseQueueResource {
     @PUT
     @Path("/{queueName}/messages")
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.UpdateMessage)
     @QueueTimer(actionName = "update-message")
     @ApiOperation(value = "Update Message")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = UpdateMessageResponse.class),
@@ -282,6 +291,7 @@ public class QueueResource extends BaseQueueResource {
     @POST
     @Path("/{queueName}/messages")
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.PutMessage)
     @QueueTimer(actionName = "publish")
     @ApiOperation(value = "Put Message")
     @ApiResponses(value = { @ApiResponse(code = 201, message = "Message Added"),
@@ -327,6 +337,7 @@ public class QueueResource extends BaseQueueResource {
     @DELETE
     @Path("/{queueName}/messages")
     @Timed
+    @AuthLevelRequired(levels = AuthorizationLevel.AckMessage)
     @QueueTimer(actionName = "ack")
     @ApiOperation(value = "Ack Message")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),

--- a/core/src/main/java/io/paradoxical/cassieq/factories/DataContextFactory.java
+++ b/core/src/main/java/io/paradoxical/cassieq/factories/DataContextFactory.java
@@ -6,10 +6,7 @@ import io.paradoxical.cassieq.dataAccess.interfaces.PointerRepository;
 import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.model.QueueDefinition;
 import io.paradoxical.cassieq.model.QueueId;
-import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.accounts.AccountName;
-
-import java.util.Optional;
 
 public interface DataContextFactory {
     QueueDataContext forQueue(QueueDefinition definition);

--- a/core/src/main/java/io/paradoxical/cassieq/model/QueryAuthUrlResult.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/QueryAuthUrlResult.java
@@ -1,0 +1,8 @@
+package io.paradoxical.cassieq.model;
+
+import lombok.Value;
+
+@Value
+public class QueryAuthUrlResult {
+    final String queryParam;
+}

--- a/core/src/main/java/io/paradoxical/cassieq/model/accounts/AccountDefinition.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/accounts/AccountDefinition.java
@@ -21,16 +21,16 @@ public class AccountDefinition {
     private AccountName accountName;
 
     @LoggingScope(scope = Scope.SKIP)
-    private ImmutableMap<String, AccountKey> keys = ImmutableMap.of();
+    private ImmutableMap<KeyName, AccountKey> keys = ImmutableMap.of();
 
     public static AccountDefinition fromRow(final Row row) {
         final Map<String, String> dbKeyMap = row.getMap(Tables.Account.KEYS, String.class, String.class);
 
-        final ImmutableMap<String, AccountKey> accountKeys =
+        final ImmutableMap<KeyName, AccountKey> accountKeys =
                 dbKeyMap.entrySet()
                         .stream()
-                        .reduce(ImmutableMap.<String, AccountKey>builder(),
-                                (builder, keyEntry) -> builder.put(keyEntry.getKey(),
+                        .reduce(ImmutableMap.<KeyName, AccountKey>builder(),
+                                (builder, keyEntry) -> builder.put(KeyName.valueOf(keyEntry.getKey()),
                                                                    AccountKey.valueOf(keyEntry.getValue())),
                                 (one, same) -> one).build();
 

--- a/core/src/main/java/io/paradoxical/cassieq/model/accounts/AccountDefinition.java
+++ b/core/src/main/java/io/paradoxical/cassieq/model/accounts/AccountDefinition.java
@@ -1,8 +1,9 @@
 package io.paradoxical.cassieq.model.accounts;
 
 import com.datastax.driver.core.Row;
+import com.godaddy.logging.LoggingScope;
+import com.godaddy.logging.Scope;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.paradoxical.cassieq.dataAccess.Tables;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,11 +11,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
 
 @Data
 @Builder
@@ -24,6 +20,7 @@ public class AccountDefinition {
 
     private AccountName accountName;
 
+    @LoggingScope(scope = Scope.SKIP)
     private ImmutableMap<String, AccountKey> keys = ImmutableMap.of();
 
     public static AccountDefinition fromRow(final Row row) {
@@ -31,11 +28,11 @@ public class AccountDefinition {
 
         final ImmutableMap<String, AccountKey> accountKeys =
                 dbKeyMap.entrySet()
-                      .stream()
-                      .reduce(ImmutableMap.<String, AccountKey>builder(),
-                              (builder, keyEntry) -> builder.put(keyEntry.getKey(),
-                                                                 AccountKey.valueOf(keyEntry.getValue())),
-                              (one, same) -> one).build();
+                        .stream()
+                        .reduce(ImmutableMap.<String, AccountKey>builder(),
+                                (builder, keyEntry) -> builder.put(keyEntry.getKey(),
+                                                                   AccountKey.valueOf(keyEntry.getValue())),
+                                (one, same) -> one).build();
 
         return AccountDefinition.builder()
                                 .accountName(AccountName.valueOf(row.getString(Tables.Account.ACCOUNT_NAME)))

--- a/core/src/main/java/io/paradoxical/cassieq/modules/auth/AuthModule.java
+++ b/core/src/main/java/io/paradoxical/cassieq/modules/auth/AuthModule.java
@@ -4,9 +4,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.governator.guice.lazy.LazySingleton;
 import io.dropwizard.auth.Authenticator;
-import io.paradoxical.cassieq.auth.AccountPrincipal;
+import io.paradoxical.cassieq.discoverable.auth.AccountPrincipal;
 import io.paradoxical.cassieq.model.auth.AuthorizedRequestCredentials;
-import io.paradoxical.cassieq.auth.SignedRequestAuthenticator;
+import io.paradoxical.cassieq.discoverable.auth.SignedRequestAuthenticator;
 import io.paradoxical.cassieq.factories.DataContextFactory;
 
 public class AuthModule extends AbstractModule {

--- a/core/src/main/java/io/paradoxical/cassieq/workers/QueueDeleter.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/QueueDeleter.java
@@ -1,5 +1,6 @@
 package io.paradoxical.cassieq.workers;
 
+import com.godaddy.logging.Logger;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import io.paradoxical.cassieq.dataAccess.DeletionJob;
@@ -14,7 +15,11 @@ import io.paradoxical.cassieq.workers.repair.RepairWorkerManager;
 
 import java.util.Optional;
 
+import static com.godaddy.logging.LoggerFactory.getLogger;
+
 public class QueueDeleter {
+    private static final Logger logger = getLogger(QueueDeleter.class);
+
     private final DataContextFactory dataContextFactory;
     private final MessageDeleterJobProcessorFactory messageDeleterJobProcessorFactory;
     private final RepairWorkerManager repairWorkerManager;
@@ -41,7 +46,10 @@ public class QueueDeleter {
             return;
         }
 
+
         final QueueDefinition queueDefinition = optionalDefinition.get();
+
+        logger.with(queueDefinition).debug("Attempting to delete queue");
 
         // This should be the first thing. this way the pointers below can't be modified further.
         final Optional<DeletionJob> deletionJob = queueRepository.tryMarkForDeletion(queueDefinition);

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/AccountRepoTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/AccountRepoTests.java
@@ -1,5 +1,6 @@
 package io.paradoxical.cassieq.unittests;
 
+import categories.BuildVerification;
 import com.google.common.collect.ImmutableMap;
 import io.paradoxical.cassieq.dataAccess.interfaces.AccountRepository;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
@@ -8,12 +9,14 @@ import io.paradoxical.cassieq.model.accounts.AccountName;
 import io.paradoxical.cassieq.model.accounts.KeyName;
 import io.paradoxical.cassieq.model.accounts.WellKnownKeyNames;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.HashMap;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(BuildVerification.class)
 public class AccountRepoTests extends DbTestBase {
     @Test
     public void test_create_account() {

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/AccountRepoTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/AccountRepoTests.java
@@ -5,6 +5,7 @@ import io.paradoxical.cassieq.dataAccess.interfaces.AccountRepository;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.accounts.KeyName;
 import io.paradoxical.cassieq.model.accounts.WellKnownKeyNames;
 import org.junit.Test;
 
@@ -56,7 +57,7 @@ public class AccountRepoTests extends DbTestBase {
 
         assertThat(accountDefinition.get().getKeys()).containsKeys(WellKnownKeyNames.Primary.getKeyName(), WellKnownKeyNames.Secondary.getKeyName());
 
-        final HashMap<String, AccountKey> stringAccountKeyHashMap = new HashMap<>(accountDefinition.get().getKeys());
+        final HashMap<KeyName, AccountKey> stringAccountKeyHashMap = new HashMap<>(accountDefinition.get().getKeys());
 
         stringAccountKeyHashMap.remove(WellKnownKeyNames.Primary.getKeyName());
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/AccountRepoTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/AccountRepoTests.java
@@ -1,0 +1,69 @@
+package io.paradoxical.cassieq.unittests;
+
+import com.google.common.collect.ImmutableMap;
+import io.paradoxical.cassieq.dataAccess.interfaces.AccountRepository;
+import io.paradoxical.cassieq.model.accounts.AccountDefinition;
+import io.paradoxical.cassieq.model.accounts.AccountKey;
+import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.accounts.WellKnownKeyNames;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AccountRepoTests extends DbTestBase {
+    @Test
+    public void test_create_account() {
+        final AccountRepository repo = getDefaultInjector().getInstance(AccountRepository.class);
+
+        final Optional<AccountDefinition> test_create_account = repo.createAccount(AccountName.valueOf("test_create_account"));
+
+        assertThat(test_create_account).isPresent();
+
+        assertThat(test_create_account.get().getKeys()).isNotEmpty();
+
+        assertThat(test_create_account.get().getKeys()).containsKeys(WellKnownKeyNames.Primary.getKeyName(), WellKnownKeyNames.Secondary.getKeyName());
+    }
+
+    @Test
+    public void test_delete_account() {
+        final AccountRepository repo = getDefaultInjector().getInstance(AccountRepository.class);
+
+        final AccountName account = AccountName.valueOf("test_delete_account");
+
+        final Optional<AccountDefinition> test_create_account = repo.createAccount(account);
+
+        assertThat(test_create_account).isPresent();
+
+        repo.deleteAccount(account);
+
+        assertThat(repo.getAccount(account)).isEmpty();
+    }
+
+    @Test
+    public void test_update_account() {
+        final AccountRepository repo = getDefaultInjector().getInstance(AccountRepository.class);
+
+        final AccountName account = AccountName.valueOf("test_update_account");
+
+        final Optional<AccountDefinition> accountDefinition = repo.createAccount(account);
+
+        assertThat(accountDefinition).isPresent();
+
+        assertThat(accountDefinition.get().getKeys()).isNotEmpty();
+
+        assertThat(accountDefinition.get().getKeys()).containsKeys(WellKnownKeyNames.Primary.getKeyName(), WellKnownKeyNames.Secondary.getKeyName());
+
+        final HashMap<String, AccountKey> stringAccountKeyHashMap = new HashMap<>(accountDefinition.get().getKeys());
+
+        stringAccountKeyHashMap.remove(WellKnownKeyNames.Primary.getKeyName());
+
+        accountDefinition.get().setKeys(ImmutableMap.copyOf(stringAccountKeyHashMap));
+
+        repo.updateAccount(accountDefinition.get());
+
+        assertThat(repo.getAccount(account).get().getKeys()).doesNotContainKeys(WellKnownKeyNames.Primary.getKeyName());
+    }
+}

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
@@ -3,6 +3,7 @@ package io.paradoxical.cassieq.unittests;
 import io.paradoxical.cassieq.admin.resources.api.v1.AccountResource;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.accounts.KeyCreateRequest;
 import io.paradoxical.cassieq.model.accounts.KeyName;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,13 +62,13 @@ public class AccountResourceTests extends DbTestBase {
 
         assertThat(entity).isNotNull();
 
-        final KeyName s = KeyName.valueOf("new-key");
+        final KeyName keyName = KeyName.valueOf("new-key");
 
-        resource.addNewKey(accountName, s);
+        resource.addNewKey(accountName, new KeyCreateRequest(keyName));
 
         final AccountDefinition updatedAccount = (AccountDefinition) resource.getAccount(accountName).getEntity();
 
-        assertThat(updatedAccount.getKeys()).containsKey(s);
+        assertThat(updatedAccount.getKeys()).containsKey(keyName);
     }
 
     @Test
@@ -84,7 +85,7 @@ public class AccountResourceTests extends DbTestBase {
 
         final KeyName keyName = KeyName.valueOf("new-key");
 
-        resource.addNewKey(accountName, keyName);
+        resource.addNewKey(accountName, new KeyCreateRequest(keyName));
 
         final AccountDefinition updatedAccount = (AccountDefinition) resource.getAccount(accountName).getEntity();
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
@@ -1,0 +1,96 @@
+package io.paradoxical.cassieq.unittests;
+
+import io.paradoxical.cassieq.admin.resources.api.v1.AccountResource;
+import io.paradoxical.cassieq.model.accounts.AccountDefinition;
+import io.paradoxical.cassieq.model.accounts.AccountName;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AccountResourceTests extends DbTestBase {
+    private AccountResource resource;
+
+    @Before
+    public void setup() {
+        resource = getDefaultInjector().getInstance(AccountResource.class);
+    }
+
+    @Test
+    public void can_add_account() {
+        final AccountName accountName = AccountName.valueOf("can_add_account");
+
+        final Response response = resource.createAccount(accountName);
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CREATED);
+
+        final AccountDefinition entity = (AccountDefinition) resource.getAccount(accountName).getEntity();
+
+        assertThat(entity).isNotNull();
+    }
+
+    @Test
+    public void can_delete_account() {
+        final AccountName accountName = AccountName.valueOf("can_delete_account");
+
+        final Response response = resource.createAccount(accountName);
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CREATED);
+
+        final AccountDefinition entity = (AccountDefinition) resource.getAccount(accountName).getEntity();
+
+        assertThat(entity).isNotNull();
+
+        assertThat(resource.deleteAccount(accountName).getStatusInfo()).isEqualTo(Response.Status.OK);
+
+        assertThat(resource.getAccount(accountName).getStatusInfo()).isEqualTo(Response.Status.NOT_FOUND);
+    }
+
+    @Test
+    public void can_add_key_to_account() {
+        final AccountName accountName = AccountName.valueOf("can_add_key_to_account");
+
+        final Response response = resource.createAccount(accountName);
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CREATED);
+
+        final AccountDefinition entity = (AccountDefinition) resource.getAccount(accountName).getEntity();
+
+        assertThat(entity).isNotNull();
+
+        resource.addNewKey(accountName, "new-key");
+
+        final AccountDefinition updatedAccount = (AccountDefinition) resource.getAccount(accountName).getEntity();
+
+        assertThat(updatedAccount.getKeys()).containsKey("new-key");
+    }
+
+    @Test
+    public void can_delete_key_from_account() {
+        final AccountName accountName = AccountName.valueOf("can_delete_key_from_account");
+
+        final Response response = resource.createAccount(accountName);
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CREATED);
+
+        final AccountDefinition entity = (AccountDefinition) resource.getAccount(accountName).getEntity();
+
+        assertThat(entity).isNotNull();
+
+        final String keyName = "new-key";
+
+        resource.addNewKey(accountName, keyName);
+
+        final AccountDefinition updatedAccount = (AccountDefinition) resource.getAccount(accountName).getEntity();
+
+        assertThat(updatedAccount.getKeys()).containsKey(keyName);
+
+        resource.deleteAccountKey(accountName, keyName);
+
+        final AccountDefinition deletedKeyAccountDef = (AccountDefinition) resource.getAccount(accountName).getEntity();
+
+        assertThat(deletedKeyAccountDef.getKeys()).doesNotContainKey(keyName);
+    }
+}

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
@@ -1,5 +1,6 @@
 package io.paradoxical.cassieq.unittests;
 
+import categories.BuildVerification;
 import io.paradoxical.cassieq.admin.resources.api.v1.AccountResource;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.accounts.AccountName;
@@ -7,11 +8,13 @@ import io.paradoxical.cassieq.model.accounts.KeyCreateRequest;
 import io.paradoxical.cassieq.model.accounts.KeyName;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(BuildVerification.class)
 public class AccountResourceTests extends DbTestBase {
     private AccountResource resource;
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
@@ -3,6 +3,7 @@ package io.paradoxical.cassieq.unittests;
 import io.paradoxical.cassieq.admin.resources.api.v1.AccountResource;
 import io.paradoxical.cassieq.model.accounts.AccountDefinition;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.accounts.KeyName;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,11 +61,13 @@ public class AccountResourceTests extends DbTestBase {
 
         assertThat(entity).isNotNull();
 
-        resource.addNewKey(accountName, "new-key");
+        final KeyName s = KeyName.valueOf("new-key");
+
+        resource.addNewKey(accountName, s);
 
         final AccountDefinition updatedAccount = (AccountDefinition) resource.getAccount(accountName).getEntity();
 
-        assertThat(updatedAccount.getKeys()).containsKey("new-key");
+        assertThat(updatedAccount.getKeys()).containsKey(s);
     }
 
     @Test
@@ -79,7 +82,7 @@ public class AccountResourceTests extends DbTestBase {
 
         assertThat(entity).isNotNull();
 
-        final String keyName = "new-key";
+        final KeyName keyName = KeyName.valueOf("new-key");
 
         resource.addNewKey(accountName, keyName);
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ApiTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ApiTester.java
@@ -16,6 +16,7 @@ import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.UpdateMessageRequest;
 import io.paradoxical.cassieq.model.UpdateMessageResponse;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.accounts.GetAuthQueryParamsRequest;
 import io.paradoxical.cassieq.model.accounts.KeyName;
 import io.paradoxical.cassieq.model.accounts.WellKnownKeyNames;
 import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
@@ -30,6 +31,7 @@ import retrofit.Response;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -121,9 +123,12 @@ public class ApiTester extends DbTestBase {
 
         accountResource.createAccount(accountName);
 
-        final QueryAuthUrlResult result = (QueryAuthUrlResult) permissionsResource.generateAuthUrl(accountName,
-                                                                                                   KeyName.valueOf(WellKnownKeyNames.Primary.getKeyName()),
-                                                                                                   AuthorizationLevel.CreateQueue.getShortForm()).getEntity();
+        final GetAuthQueryParamsRequest getAuthQueryParamsRequest = new GetAuthQueryParamsRequest(accountName,
+                                                                                                  KeyName.valueOf(WellKnownKeyNames.Primary.getKeyName()),
+                                                                                                  Collections.singletonList(AuthorizationLevel.CreateQueue));
+
+        final QueryAuthUrlResult result = (QueryAuthUrlResult) permissionsResource.generateAuthUrl(getAuthQueryParamsRequest)
+                                                                                  .getEntity();
 
         final String queryParam = result.getQueryParam();
 
@@ -154,9 +159,11 @@ public class ApiTester extends DbTestBase {
 
         accountResource.createAccount(accountName);
 
-        final QueryAuthUrlResult result = (QueryAuthUrlResult) permissionsResource.generateAuthUrl(accountName,
-                                                                                                   KeyName.valueOf(WellKnownKeyNames.Primary.getKeyName()),
-                                                                                                   AuthorizationLevel.ReadMessage.getShortForm()).getEntity();
+        final GetAuthQueryParamsRequest getAuthQueryParamsRequest = new GetAuthQueryParamsRequest(accountName,
+                                                                                                  KeyName.valueOf(WellKnownKeyNames.Primary.getKeyName()),
+                                                                                                  Collections.singletonList(AuthorizationLevel.ReadMessage));
+
+        final QueryAuthUrlResult result = (QueryAuthUrlResult) permissionsResource.generateAuthUrl(getAuthQueryParamsRequest).getEntity();
 
         final String queryParam = result.getQueryParam();
 
@@ -190,9 +197,11 @@ public class ApiTester extends DbTestBase {
 
         accountResource.createAccount(accountName);
 
-        final QueryAuthUrlResult result = (QueryAuthUrlResult) permissionsResource.generateAuthUrl(accountName,
-                                                                                                   KeyName.valueOf(WellKnownKeyNames.Primary.getKeyName()),
-                                                                                                   AuthorizationLevel.CreateQueue.getShortForm()).getEntity();
+        final GetAuthQueryParamsRequest getAuthQueryParamsRequest = new GetAuthQueryParamsRequest(accountName,
+                                                                                                  KeyName.valueOf(WellKnownKeyNames.Primary.getKeyName()),
+                                                                                                  Collections.singletonList(AuthorizationLevel.CreateQueue));
+
+        final QueryAuthUrlResult result = (QueryAuthUrlResult) permissionsResource.generateAuthUrl(getAuthQueryParamsRequest).getEntity();
 
         final String queryParam = result.getQueryParam();
 
@@ -220,9 +229,11 @@ public class ApiTester extends DbTestBase {
 
         accountResource.createAccount(accountName);
 
-        final QueryAuthUrlResult result = (QueryAuthUrlResult) permissionsResource.generateAuthUrl(accountName,
-                                                                                                   KeyName.valueOf(WellKnownKeyNames.Primary.getKeyName()),
-                                                                                                   AuthorizationLevel.CreateQueue.getShortForm()).getEntity();
+        final GetAuthQueryParamsRequest getAuthQueryParamsRequest = new GetAuthQueryParamsRequest(accountName,
+                                                                                                  KeyName.valueOf(WellKnownKeyNames.Primary.getKeyName()),
+                                                                                                  Collections.singletonList(AuthorizationLevel.CreateQueue));
+
+        final QueryAuthUrlResult result = (QueryAuthUrlResult) permissionsResource.generateAuthUrl(getAuthQueryParamsRequest).getEntity();
 
         final String queryParam = result.getQueryParam();
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/YamlConfigTest.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/YamlConfigTest.java
@@ -1,7 +1,6 @@
 package io.paradoxical.cassieq.unittests;
 
-import io.paradoxical.cassieq.ServiceApplication;
-import io.paradoxical.cassieq.bundles.GuiceBundleProvider;
+import io.paradoxical.cassieq.unittests.server.TestService;
 import io.paradoxical.common.test.junit.RetryRule;
 import io.paradoxical.common.test.logging.TestLoggingInitializer;
 import org.junit.Ignore;
@@ -11,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @RunWith(Parameterized.class)
@@ -40,7 +40,7 @@ public class YamlConfigTest {
 
     @Test
     public void test_yaml_files() throws Exception {
-        final ServiceApplication serviceApplication = new ServiceApplication(new GuiceBundleProvider());
+        final TestService serviceApplication = new TestService(Collections.emptyList());
 
         serviceApplication.run("server", configPath);
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/server/TestService.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/server/TestService.java
@@ -1,8 +1,7 @@
 package io.paradoxical.cassieq.unittests.server;
 
-import com.google.inject.Injector;
+import com.godaddy.logging.Logger;
 import com.google.inject.Module;
-import com.hubspot.dropwizard.guice.InjectorFactory;
 import io.dropwizard.setup.Environment;
 import io.paradoxical.cassieq.ServiceApplication;
 import io.paradoxical.cassieq.ServiceConfiguration;
@@ -15,7 +14,11 @@ import lombok.Getter;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import static com.godaddy.logging.LoggerFactory.getLogger;
+
 public class TestService extends ServiceApplication implements ModuleOverrider {
+    private static final Logger logger = getLogger(TestService.class);
+
 
     private final CountDownLatch runLatch = new CountDownLatch(1);
 
@@ -31,6 +34,20 @@ public class TestService extends ServiceApplication implements ModuleOverrider {
 
     public TestService(final List<OverridableModule> modules) {
         super(new TestGuiceBundleProvier(modules));
+    }
+
+
+    public void stop() {
+        try {
+            logger.info("Stopping!");
+
+            env.getApplicationContext().getServer().stop();
+
+            logger.info("Stopped");
+        }
+        catch (Exception ex) {
+            logger.error(ex, "Unclean stop occurred!");
+        }
     }
 
     @Override

--- a/model/src/main/java/io/paradoxical/cassieq/model/accounts/GetAuthQueryParamsRequest.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/accounts/GetAuthQueryParamsRequest.java
@@ -1,0 +1,19 @@
+package io.paradoxical.cassieq.model.accounts;
+
+import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
+import lombok.Value;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Value
+public class GetAuthQueryParamsRequest {
+    @NotNull
+    private AccountName accountName;
+
+    @NotNull
+    private KeyName keyName;
+
+    @NotNull
+    private List<AuthorizationLevel> levels;
+}

--- a/model/src/main/java/io/paradoxical/cassieq/model/accounts/KeyCreateRequest.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/accounts/KeyCreateRequest.java
@@ -1,0 +1,8 @@
+package io.paradoxical.cassieq.model.accounts;
+
+import lombok.Value;
+
+@Value
+public class KeyCreateRequest {
+    private KeyName keyName;
+}

--- a/model/src/main/java/io/paradoxical/cassieq/model/accounts/KeyName.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/accounts/KeyName.java
@@ -1,0 +1,62 @@
+package io.paradoxical.cassieq.model.accounts;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.paradoxical.common.valuetypes.StringValue;
+import io.paradoxical.common.valuetypes.adapters.xml.JaxbStringValueAdapter;
+import jdk.nashorn.internal.ir.annotations.Immutable;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.io.IOException;
+
+@Immutable
+@XmlJavaTypeAdapter(value = KeyName.XmlAdapter.class)
+@JsonSerialize(using = KeyName.JsonSerializeAdapter.class)
+@JsonDeserialize(using = KeyName.JsonDeserializeAdapater.class)
+public final class KeyName extends StringValue {
+    protected KeyName(final String value) {
+        super(value);
+    }
+
+    public static KeyName valueOf(String value) {
+        return new KeyName(StringUtils.trimToEmpty(value));
+    }
+
+    public static KeyName valueOf(StringValue value) {
+        return KeyName.valueOf(value.get());
+    }
+
+    public static class XmlAdapter extends JaxbStringValueAdapter<KeyName> {
+        @Override
+        protected KeyName createNewInstance(String value) {
+            return KeyName.valueOf(value);
+        }
+    }
+
+    public static class JsonDeserializeAdapater extends JsonDeserializer<KeyName> {
+
+        @Override
+        public KeyName deserialize(
+                final JsonParser jp, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            return KeyName.valueOf(jp.getValueAsString());
+        }
+    }
+
+    public static class JsonSerializeAdapter extends JsonSerializer<KeyName> {
+        @Override
+        public void serialize(
+                final KeyName value, final JsonGenerator jgen, final SerializerProvider provider) throws
+                                                                                                  IOException,
+                                                                                                  JsonProcessingException {
+            jgen.writeString(value.get());
+        }
+    }
+}

--- a/model/src/main/java/io/paradoxical/cassieq/model/accounts/WellKnownKeyNames.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/accounts/WellKnownKeyNames.java
@@ -3,13 +3,13 @@ package io.paradoxical.cassieq.model.accounts;
 import lombok.Getter;
 
 public enum WellKnownKeyNames {
-    Primary("primary"),
-    Secondary("secondary");
+    Primary(KeyName.valueOf("primary")),
+    Secondary(KeyName.valueOf("secondary"));
 
     @Getter
-    private final String keyName;
+    private final KeyName keyName;
 
-    WellKnownKeyNames(final String keyName) {
+    WellKnownKeyNames(final KeyName keyName) {
 
         this.keyName = keyName;
     }

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/AuthorizedRequestCredentials.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/AuthorizedRequestCredentials.java
@@ -1,25 +1,13 @@
 package io.paradoxical.cassieq.model.auth;
 
 import com.godaddy.logging.Logger;
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableCollection;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
-import io.paradoxical.cassieq.model.accounts.AccountName;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import javax.validation.constraints.NotNull;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 import java.util.Collection;
-import java.util.EnumSet;
-import java.util.Set;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
@@ -36,14 +24,11 @@ public class AuthorizedRequestCredentials {
     public boolean verify(Collection<AccountKey> keys) throws Exception {
 
         for (AccountKey key : keys) {
-
-            if(requestParameters.verify(key)){
+            if (requestParameters.verify(key)) {
                 return true;
             }
         }
 
         return false;
     }
-
-
 }

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/HMAC.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/HMAC.java
@@ -1,0 +1,5 @@
+package io.paradoxical.cassieq.model.auth;
+
+public class HMAC {
+    public static final String SHA256 = "HmacSHA256";
+}

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/MacProviders.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/MacProviders.java
@@ -1,0 +1,26 @@
+package io.paradoxical.cassieq.model.auth;
+
+import io.paradoxical.cassieq.model.accounts.AccountKey;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+public class MacProviders {
+
+    public static Mac Hmac256(AccountKey key) {
+        final String hmacSHA2561Algo = HMAC.SHA256;
+
+        try {
+            final Mac hmacSHA256 = Mac.getInstance(hmacSHA2561Algo);
+
+            hmacSHA256.init(new SecretKeySpec(key.getBytes(), hmacSHA2561Algo));
+
+            return hmacSHA256;
+        }
+        catch (InvalidKeyException | NoSuchAlgorithmException e) {
+            throw new AssertionError("Error initializing mac", e);
+        }
+    }
+}

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/MacProviders.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/MacProviders.java
@@ -9,7 +9,7 @@ import java.security.NoSuchAlgorithmException;
 
 public class MacProviders {
 
-    public static Mac Hmac256(AccountKey key) {
+    public static Mac HmacSha256(AccountKey key) {
         final String hmacSHA2561Algo = HMAC.SHA256;
 
         try {

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignatureGenerator.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignatureGenerator.java
@@ -1,12 +1,8 @@
 package io.paradoxical.cassieq.model.auth;
 
 import com.godaddy.logging.Logger;
-import io.paradoxical.cassieq.model.accounts.AccountKey;
 
 import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
@@ -15,21 +11,6 @@ import static com.godaddy.logging.LoggerFactory.getLogger;
  * Signs paramters
  */
 public interface SignatureGenerator {
-
-    default String computeSignature(AccountKey key) {
-        final String hmacSHA2561Algo = HMAC.SHA256;
-
-        try {
-            final Mac hmacSHA256 = Mac.getInstance(hmacSHA2561Algo);
-
-            hmacSHA256.init(new SecretKeySpec(key.getBytes(), hmacSHA2561Algo));
-
-            return computeSignature(hmacSHA256);
-        }
-        catch (InvalidKeyException | NoSuchAlgorithmException e) {
-            throw new AssertionError("Error initializing mac", e);
-        }
-    }
 
     default String computeSignature(final Mac hmac) {
         final Logger logger = getLogger(SignatureGenerator.class);

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignatureGenerator.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignatureGenerator.java
@@ -16,13 +16,19 @@ import static com.godaddy.logging.LoggerFactory.getLogger;
  */
 public interface SignatureGenerator {
 
-    default String computeSignature(AccountKey key) throws InvalidKeyException, NoSuchAlgorithmException {
-        final String hmacSHA2561Algo = "HmacSHA256";
-        final Mac hmacSHA256 = Mac.getInstance(hmacSHA2561Algo);
+    default String computeSignature(AccountKey key) {
+        final String hmacSHA2561Algo = HMAC.SHA256;
 
-        hmacSHA256.init(new SecretKeySpec(key.getBytes(), hmacSHA2561Algo));
+        try {
+            final Mac hmacSHA256 = Mac.getInstance(hmacSHA2561Algo);
 
-        return computeSignature(hmacSHA256);
+            hmacSHA256.init(new SecretKeySpec(key.getBytes(), hmacSHA2561Algo));
+
+            return computeSignature(hmacSHA256);
+        }
+        catch (InvalidKeyException | NoSuchAlgorithmException e) {
+            throw new AssertionError("Error initializing mac", e);
+        }
     }
 
     default String computeSignature(final Mac hmac) {

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignatureGenerator.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignatureGenerator.java
@@ -1,0 +1,43 @@
+package io.paradoxical.cassieq.model.auth;
+
+import com.godaddy.logging.Logger;
+import io.paradoxical.cassieq.model.accounts.AccountKey;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import static com.godaddy.logging.LoggerFactory.getLogger;
+
+/**
+ * Signs paramters
+ */
+public interface SignatureGenerator {
+
+    default String computeSignature(AccountKey key) throws InvalidKeyException, NoSuchAlgorithmException {
+        final String hmacSHA2561Algo = "HmacSHA256";
+        final Mac hmacSHA256 = Mac.getInstance(hmacSHA2561Algo);
+
+        hmacSHA256.init(new SecretKeySpec(key.getBytes(), hmacSHA2561Algo));
+
+        return computeSignature(hmacSHA256);
+    }
+
+    default String computeSignature(final Mac hmac) {
+        final Logger logger = getLogger(SignatureGenerator.class);
+
+        final String stringToSign = getStringToSign();
+
+        final Base64.Encoder signatureEncoder = Base64.getUrlEncoder().withoutPadding();
+
+        logger.with("signed-string", stringToSign).debug("Computing signature of string");
+
+        final byte[] bytes = hmac.doFinal(stringToSign.getBytes());
+
+        return signatureEncoder.encodeToString(bytes);
+    }
+
+    String getStringToSign();
+}

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignatureJoiner.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignatureJoiner.java
@@ -1,0 +1,9 @@
+package io.paradoxical.cassieq.model.auth;
+
+import com.google.common.base.Joiner;
+
+public final class SignatureJoiner {
+    public static final Joiner componentJoiner = Joiner.on('\n')
+                                                       .skipNulls();
+
+}

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedParametersBase.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedParametersBase.java
@@ -18,7 +18,7 @@ public abstract class SignedParametersBase implements RequestParameters, Signatu
             return false;
         }
 
-        return verifySignature(MacProviders.Hmac256(key));
+        return verifySignature(MacProviders.HmacSha256(key));
     }
 
     private boolean verifySignature(Mac hmac) {

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedParametersBase.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedParametersBase.java
@@ -5,7 +5,6 @@ import com.google.common.base.Strings;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
 
 import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
@@ -19,12 +18,7 @@ public abstract class SignedParametersBase implements RequestParameters, Signatu
             return false;
         }
 
-        final Mac hmacSHA256 = Mac.getInstance(HMAC.SHA256);
-        final SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), HMAC.SHA256);
-
-        hmacSHA256.init(secretKeySpec);
-
-        return verifySignature(hmacSHA256);
+        return verifySignature(MacProviders.Hmac256(key));
     }
 
     private boolean verifySignature(Mac hmac) {

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedParametersBase.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedParametersBase.java
@@ -1,22 +1,17 @@
 package io.paradoxical.cassieq.model.auth;
 
 import com.godaddy.logging.Logger;
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import io.paradoxical.cassieq.model.accounts.AccountKey;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import java.util.Base64;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
-public abstract class SignedParametersBase implements RequestParameters {
+public abstract class SignedParametersBase implements RequestParameters, SignatureGenerator {
 
     private static final Logger logger = getLogger(SignedParametersBase.class);
-
-    protected static final Joiner signatureComponentJoiner = Joiner.on('\n')
-                                                                   .skipNulls();
 
     @Override
     public boolean verify(final AccountKey key) throws Exception {
@@ -38,18 +33,6 @@ public abstract class SignedParametersBase implements RequestParameters {
         return computedSignature.equals(getProvidedSignature());
     }
 
-    public String computeSignature(final Mac hmac) {
-        final String signedString = getSignedString();
-
-        final Base64.Encoder signatureEncoder = Base64.getUrlEncoder().withoutPadding();
-
-        logger.with("signed-string", signedString).debug("Computing signature of string");
-
-        final byte[] bytes = hmac.doFinal(signedString.getBytes());
-        return signatureEncoder.encodeToString(bytes);
-    }
 
     protected abstract String getProvidedSignature();
-
-    protected abstract String getSignedString();
 }

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedParametersBase.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedParametersBase.java
@@ -19,8 +19,8 @@ public abstract class SignedParametersBase implements RequestParameters, Signatu
             return false;
         }
 
-        final Mac hmacSHA256 = Mac.getInstance("HmacSHA256");
-        final SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), "HmacSHA256");
+        final Mac hmacSHA256 = Mac.getInstance(HMAC.SHA256);
+        final SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), HMAC.SHA256);
 
         hmacSHA256.init(secretKeySpec);
 

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedRequestParameters.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedRequestParameters.java
@@ -3,17 +3,13 @@ package io.paradoxical.cassieq.model.auth;
 import com.godaddy.logging.Logger;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
-import io.paradoxical.cassieq.model.accounts.AccountKey;
 import io.paradoxical.cassieq.model.accounts.AccountName;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import javax.validation.constraints.NotNull;
-import java.util.Base64;
 import java.util.EnumSet;
 
 import static com.godaddy.logging.LoggerFactory.getLogger;
@@ -45,7 +41,7 @@ public class SignedRequestParameters extends SignedParametersBase implements Req
         return AuthorizationLevel.All;
     }
 
-    public String getSignedString() {
+    public String getStringToSign() {
         return Joiner.on("\n")
                      .skipNulls()
                      .join(accountName.get(),

--- a/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedUrlParameterGenerator.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/auth/SignedUrlParameterGenerator.java
@@ -2,7 +2,6 @@ package io.paradoxical.cassieq.model.auth;
 
 import com.godaddy.logging.Logger;
 import io.paradoxical.cassieq.model.accounts.AccountName;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
@@ -13,12 +12,11 @@ import java.util.EnumSet;
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
 /**
- * Represents the parsed signed URL pamaters from a request
+ * Generates a signed query param set for use for clients
  */
 @EqualsAndHashCode(callSuper = false)
 @Value
-@Builder
-public class SignedUrlParameters extends SignedParametersBase implements RequestParameters {
+public class SignedUrlParameterGenerator implements SignatureGenerator {
 
     private static final Logger logger = getLogger(SignedUrlParameters.class);
 
@@ -28,20 +26,13 @@ public class SignedUrlParameters extends SignedParametersBase implements Request
 
     @NonNull
     @NotNull
-    private final String querySignature;
-
-    @NonNull
-    @NotNull
     private final EnumSet<AuthorizationLevel> authorizationLevels;
 
     @Override
-    protected String getProvidedSignature() {
-        return querySignature;
-    }
-
-    @Override
     public String getStringToSign() {
-        return new SignedUrlParameterGenerator(accountName, authorizationLevels).getStringToSign();
+        return SignatureJoiner
+                .componentJoiner
+                .join(accountName.get(),
+                      AuthorizationLevel.stringify(authorizationLevels));
     }
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
         <!-- Library Versions -->
         <io.paradoxical.common.test>1.0-SNAPSHOT</io.paradoxical.common.test>
-        <io.paradoxical.common>1.1-SNAPSHOT</io.paradoxical.common>
+        <io.paradoxical.common>1.2-SNAPSHOT</io.paradoxical.common>
         <io.paradoxical.common.web>1.1-SNAPSHOT</io.paradoxical.common.web>
         <io.paradoxical.cassandra-loader>1.2-SNAPSHOT</io.paradoxical.cassandra-loader>
         <guice.version>4.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,10 +73,9 @@
 
         <!-- Library Versions -->
         <io.paradoxical.common.test>1.0-SNAPSHOT</io.paradoxical.common.test>
-        <io.paradoxical.common>1.0-SNAPSHOT</io.paradoxical.common>
-        <io.paradoxical.common.web>1.0-SNAPSHOT</io.paradoxical.common.web>
-        <io.paradoxical.cassandra.leadership>1.0-SNAPSHOT</io.paradoxical.cassandra.leadership>
-        <io.paradoxical.cassandra-loader>1.0-SNAPSHOT</io.paradoxical.cassandra-loader>
+        <io.paradoxical.common>1.1-SNAPSHOT</io.paradoxical.common>
+        <io.paradoxical.common.web>1.1-SNAPSHOT</io.paradoxical.common.web>
+        <io.paradoxical.cassandra-loader>1.2-SNAPSHOT</io.paradoxical.cassandra-loader>
         <guice.version>4.0</guice.version>
         <apache.collections4.version>4.0</apache.collections4.version>
         <godaddy.logging.version>1.0</godaddy.logging.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <java.version>1.8</java.version>
 
         <!-- Library Versions -->
-        <io.paradoxical.common.test>1.0-SNAPSHOT</io.paradoxical.common.test>
+        <io.paradoxical.common.test>1.1-SNAPSHOT</io.paradoxical.common.test>
         <io.paradoxical.common>1.2-SNAPSHOT</io.paradoxical.common>
         <io.paradoxical.common.web>1.1-SNAPSHOT</io.paradoxical.common.web>
         <io.paradoxical.cassandra-loader>1.2-SNAPSHOT</io.paradoxical.cassandra-loader>


### PR DESCRIPTION
Addresses #60 and exposes a permissions api to generate query string auth. Updating readme, and adding lots of tests 

Also addresses #53 account delete, which kicks off jobs to delete all linked queues as well.
