### PR TITLE
Adding DLQ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,24 @@ but CassieQ leverages lightweight transactions and message bucketizing to avoid 
 
 CassieQ provides:
 
-- at least once delivery
-- invisiblity of messages
-- simple API of get/ack
-- highly scaleable
-- authentication
-- queue statistics (via graphite)
+- At least once delivery
+    - You may get a message more than once. It is important for the client consumer to be able to handle this scenario
+- Invisiblity of messages
+    - When a message is consumed, you can say how long it should not be re-visible for. When it becomes revisible (after that time)
+   it can be redelivered to another consumer. You can also specify initial invisibility when putting messages in, so they won't be available
+   for a consumer until that time.
+- Simple API 
+    - A simple REST api. Java client available
+- Highly scaleable due to backing of cassandra
+- Durable
+    - If the API accepts a message, it is persisted and will not be lost.  
+- Secured with granularty by account and specific actions 
+- Queue statistics (via graphite)
+    - The only native stat is queue size, however granular metrics regarding consume/ack/publish rates are all published as graphite metrics
+- DLQ support
+    - DLQ's can be chained for more complex topologies
+- Max message delivery
+    - Avoid poison messages with max delivery counts
 
 ## To run
 
@@ -88,7 +100,8 @@ the tracking tables for queues.
 
 ## Admin panel
 
-The admin API is available at `host:8081/admin`
+The admin API is available at `host:8081/admin`. You will need to access the admin panel to administer accounts 
+and get account access URLs for actions on endpoints.
 
 ## API
 
@@ -112,7 +125,7 @@ CassieQ has three forms of authentication
  
 ### Claims
 
-Claims by account is the preferred method. To generate a claim for a user, you can create a named account key for that group (such as "ui-members") and create
+Claims by account is the *preferred* method. To generate a claim for a user, you can create a named account key for that group (such as "ui-members") and create
 permission based url params for them. This may look of the form:
 
 ```
@@ -143,11 +156,14 @@ Global account access is via header parameters. Add your account key as the auth
 Key: <your key>
 ```
 
+This is not the recommended authentication case but is supported and is currently the only way to experiment with the 
+swagger API.  Put your access key into the swagger api key section for access.
+
 ### Endpoint singing by key
 
-This also provides global access by account.
+This also provides global access by account but doesn't expose your access key publicly.  
 
-Generate auth tokens by signing using Hmac256 the following:
+Generate auth tokens by signing using Hmac256 the following (newlines using `\n`)
 
 ```
 AccountName

--- a/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqApi.java
+++ b/client/src/main/java/io/paradoxical/cassieq/api/client/CassieqApi.java
@@ -10,6 +10,7 @@ import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.model.UpdateMessageRequest;
 import io.paradoxical.cassieq.model.UpdateMessageResponse;
 import io.paradoxical.cassieq.model.accounts.AccountName;
+import io.paradoxical.cassieq.model.mappers.Mappers;
 import retrofit.Call;
 import retrofit.JacksonConverterFactory;
 import retrofit.Retrofit;
@@ -44,7 +45,7 @@ public interface CassieqApi {
 
         Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl(baseUri)
-                .addConverterFactory(JacksonConverterFactory.create())
+                .addConverterFactory(JacksonConverterFactory.create(Mappers.getJson()))
                 .client(client)
                 .build();
 

--- a/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
+++ b/core/src/main/java/io/paradoxical/cassieq/dataAccess/Tables.java
@@ -37,6 +37,7 @@ public final class Tables {
         public static final String REPAIR_WORKER_POLL_FREQ_SECONDS = "repair_worker_poll_freq_seconds";
         public static final String REPAIR_WORKER_TOMBSTONE_BUCKET_TIMEOUT_SECONDS = "repair_worker_tombstone_bucket_timeout_seconds";
         public static final String DELETE_BUCKETS_AFTER_FINALIZATION = "delete_buckets_after_finalization";
+        public static final String DLQ_NAME = "dlq_queue_name";
     }
 
     public static class QueueStats {

--- a/core/src/main/java/io/paradoxical/cassieq/modules/DefaultApplicationModules.java
+++ b/core/src/main/java/io/paradoxical/cassieq/modules/DefaultApplicationModules.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class DefaultApplicationModules {
     public static List<Module> getModules() {
         return Arrays.asList(
+                new MessagePublisherModule(),
                 new LeadershipModule(),
                 new ClusteringModule(),
                 new MessageDeletionModule(),

--- a/core/src/main/java/io/paradoxical/cassieq/modules/MessagePublisherModule.java
+++ b/core/src/main/java/io/paradoxical/cassieq/modules/MessagePublisherModule.java
@@ -1,0 +1,12 @@
+package io.paradoxical.cassieq.modules;
+
+import com.google.inject.AbstractModule;
+import io.paradoxical.cassieq.workers.DefaultMessagePublisher;
+import io.paradoxical.cassieq.workers.MessagePublisher;
+
+public class MessagePublisherModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(MessagePublisher.class).to(DefaultMessagePublisher.class);
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/serialization/JacksonJsonMapper.java
+++ b/core/src/main/java/io/paradoxical/cassieq/serialization/JacksonJsonMapper.java
@@ -1,11 +1,8 @@
 package io.paradoxical.cassieq.serialization;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
+import io.paradoxical.cassieq.model.mappers.Mappers;
 
 import java.io.IOException;
 
@@ -14,18 +11,7 @@ public class JacksonJsonMapper implements JsonMapper {
     private final ObjectMapper mapper;
 
     public JacksonJsonMapper() {
-        this.mapper = new ObjectMapper().configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-                                        .configure(SerializationFeature.INDENT_OUTPUT, true)
-                                        .configure(SerializationFeature.WRITE_NULL_MAP_VALUES, true)
-                                        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                                        .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
-                                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-                                        .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
-                                        .configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
-                                        .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
-
-        this.mapper.registerModule(new JodaModule());
+        this.mapper = Mappers.getJson();
     }
 
     @Override

--- a/core/src/main/java/io/paradoxical/cassieq/workers/DefaultMessagePublisher.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/DefaultMessagePublisher.java
@@ -1,0 +1,48 @@
+package io.paradoxical.cassieq.workers;
+
+import com.godaddy.logging.Logger;
+import com.google.inject.Inject;
+import io.paradoxical.cassieq.dataAccess.exceptions.ExistingMonotonFoundException;
+import io.paradoxical.cassieq.factories.MessageRepoFactory;
+import io.paradoxical.cassieq.factories.MonotonicRepoFactory;
+import io.paradoxical.cassieq.model.Message;
+import io.paradoxical.cassieq.model.QueueDefinition;
+import org.joda.time.Duration;
+
+import static com.godaddy.logging.LoggerFactory.getLogger;
+
+public class DefaultMessagePublisher implements MessagePublisher {
+
+    private static final Logger logger = getLogger(DefaultMessagePublisher.class);
+
+    private final MonotonicRepoFactory monotonicRepository;
+    private final MessageRepoFactory messageRepoFactory;
+
+    @Inject
+    public DefaultMessagePublisher(
+            MonotonicRepoFactory monotonicRepository,
+            MessageRepoFactory messageRepoFactory) {
+        this.monotonicRepository = monotonicRepository;
+        this.messageRepoFactory = messageRepoFactory;
+    }
+
+    @Override
+    public void put(final QueueDefinition queueDefinition, final String message, final Long initialInvisibilityTimeSeconds) throws ExistingMonotonFoundException {
+        final Message messageToInsert = Message.builder()
+                                               .blob(message)
+                                               .index(monotonicRepository.forQueue(queueDefinition.getId())
+                                                                         .nextMonotonic())
+                                               .build();
+
+        final Duration initialInvisibility = Duration.standardSeconds(initialInvisibilityTimeSeconds);
+
+        messageRepoFactory.forQueue(queueDefinition)
+                          .putMessage(messageToInsert,
+                                      initialInvisibility);
+
+        logger.with("index", messageToInsert.getIndex())
+              .with("tag", messageToInsert.getTag())
+              .with("queue-id", queueDefinition.getId())
+              .debug("Adding message");
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/workers/MessageConsumer.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/MessageConsumer.java
@@ -3,7 +3,9 @@ package io.paradoxical.cassieq.workers;
 import com.godaddy.logging.Logger;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import io.paradoxical.cassieq.dataAccess.exceptions.ExistingMonotonFoundException;
 import io.paradoxical.cassieq.dataAccess.interfaces.MessageRepository;
+import io.paradoxical.cassieq.factories.DataContextFactory;
 import io.paradoxical.cassieq.factories.MessageRepoFactory;
 import io.paradoxical.cassieq.model.Message;
 import io.paradoxical.cassieq.model.QueueDefinition;
@@ -14,6 +16,8 @@ import java.util.Optional;
 import static com.godaddy.logging.LoggerFactory.getLogger;
 
 public class MessageConsumer {
+    private final MessagePublisher messagePublisher;
+    private final DataContextFactory dataContextFactory;
     private Logger logger = getLogger(MessageConsumer.class);
 
     private final QueueDefinition queueDefinition;
@@ -23,7 +27,11 @@ public class MessageConsumer {
     @Inject
     public MessageConsumer(
             MessageRepoFactory messageRepoFactory,
+            MessagePublisher messagePublisher,
+            DataContextFactory dataContextFactory,
             @Assisted QueueDefinition definition) {
+        this.messagePublisher = messagePublisher;
+        this.dataContextFactory = dataContextFactory;
         messageRepository = messageRepoFactory.forQueue(definition);
 
         this.queueDefinition = definition;
@@ -33,6 +41,7 @@ public class MessageConsumer {
 
     /**
      * Consumes with business logic
+     *
      * @param message
      * @param invisiblity
      * @return
@@ -57,6 +66,23 @@ public class MessageConsumer {
                   .with("already-delivered-count", message.getDeliveryCount())
                   .with("max-delivery-count", queueDefinition.getMaxDeliveryCount())
                   .warn("Message exceeded delivery count, acking and moving on");
+
+            if (queueDefinition.getDlqName().isPresent()) {
+                final Optional<QueueDefinition> dlqDefinitionOptional = dataContextFactory.forAccount(queueDefinition.getAccountName())
+                                                                                          .getActiveQueue(queueDefinition.getDlqName().get());
+
+                if (dlqDefinitionOptional.isPresent()) {
+                    final QueueDefinition dlqDefinition = dlqDefinitionOptional.get();
+
+                    // publish this message to the DLQ
+                    try {
+                        messagePublisher.put(dlqDefinition, message.getBlob(), 0L);
+                    }
+                    catch (ExistingMonotonFoundException e) {
+                        logger.error(e, "Error republishing message to dlq!");
+                    }
+                }
+            }
 
             if (ackMessage(message)) {
                 logger.with("tag", message.getTag()).success("Acked dead message");

--- a/core/src/main/java/io/paradoxical/cassieq/workers/MessagePublisher.java
+++ b/core/src/main/java/io/paradoxical/cassieq/workers/MessagePublisher.java
@@ -1,0 +1,9 @@
+package io.paradoxical.cassieq.workers;
+
+import io.paradoxical.cassieq.dataAccess.exceptions.ExistingMonotonFoundException;
+import io.paradoxical.cassieq.model.QueueDefinition;
+
+public interface MessagePublisher {
+    void put(QueueDefinition queueDefinition, String message, Long invisTimeSeconds) throws ExistingMonotonFoundException;
+}
+

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/AccountResourceTests.java
@@ -48,7 +48,7 @@ public class AccountResourceTests extends DbTestBase {
 
         assertThat(entity).isNotNull();
 
-        assertThat(resource.deleteAccount(accountName).getStatusInfo()).isEqualTo(Response.Status.OK);
+        assertThat(resource.deleteAccount(accountName).getStatusInfo()).isEqualTo(Response.Status.NO_CONTENT);
 
         assertThat(resource.getAccount(accountName).getStatusInfo()).isEqualTo(Response.Status.NOT_FOUND);
     }

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ApiTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ApiTester.java
@@ -20,6 +20,7 @@ import io.paradoxical.cassieq.model.accounts.GetAuthQueryParamsRequest;
 import io.paradoxical.cassieq.model.accounts.KeyName;
 import io.paradoxical.cassieq.model.accounts.WellKnownKeyNames;
 import io.paradoxical.cassieq.model.auth.AuthorizationLevel;
+import io.paradoxical.cassieq.unittests.modules.HazelcastTestModule;
 import io.paradoxical.cassieq.unittests.modules.InMemorySessionProvider;
 import io.paradoxical.cassieq.unittests.server.SelfHostServer;
 import org.junit.AfterClass;
@@ -51,7 +52,7 @@ public class ApiTester extends DbTestBase {
 
     @BeforeClass
     public static void setup() throws InterruptedException, NoSuchAlgorithmException, InvalidKeyException {
-        server = new SelfHostServer(new InMemorySessionProvider(session));
+        server = new SelfHostServer(new InMemorySessionProvider(session), new HazelcastTestModule("api-tester"));
 
         server.start();
 

--- a/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
+++ b/core/src/test/java/io/paradoxical/cassieq/unittests/ReaderTester.java
@@ -2,14 +2,10 @@ package io.paradoxical.cassieq.unittests;
 
 import categories.BuildVerification;
 import com.google.inject.Injector;
-import io.paradoxical.cassieq.dataAccess.interfaces.QueueRepository;
 import io.paradoxical.cassieq.factories.DataContextFactory;
-import io.paradoxical.cassieq.model.BucketSize;
 import io.paradoxical.cassieq.model.InvisibilityMessagePointer;
 import io.paradoxical.cassieq.model.Message;
 import io.paradoxical.cassieq.model.MessageUpdateRequest;
-import io.paradoxical.cassieq.model.QueueDefinition;
-import io.paradoxical.cassieq.model.QueueName;
 import io.paradoxical.cassieq.unittests.time.TestClock;
 import org.joda.time.Duration;
 import org.junit.Before;

--- a/db/scripts/01_cassandra_queue.cql
+++ b/db/scripts/01_cassandra_queue.cql
@@ -8,6 +8,7 @@ CREATE TABLE queue (
   repair_worker_poll_freq_seconds int,
   repair_worker_tombstone_bucket_timeout_seconds int,
   delete_buckets_after_finalization boolean,
+  dlq_queue_name text,
   version int,
 
   PRIMARY KEY (account_name, queuename)

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -31,6 +31,31 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk7</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.paradoxical</groupId>
+            <artifactId>jackson-lombok</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit</groupId>
             <artifactId>converter-jackson</artifactId>
         </dependency>

--- a/model/src/main/java/io/paradoxical/cassieq/model/QueueCreateOptions.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/QueueCreateOptions.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 @Data
 @Builder
@@ -46,13 +47,21 @@ public class QueueCreateOptions {
      */
     private final Boolean deleteBucketsAfterFinalize;
 
+    /**
+     * An optional DLQ linked to this queue. When messages reach their max delivery
+     * count, they will be re-published to this queue. If no DLQ is specified, the messages
+     * are discarded after max delivery.
+     */
+    private final Optional<QueueName> dlqName;
+
     public QueueCreateOptions(QueueName queueName) {
         this(queueName,
              DEFAULT_BUCKET_SIZE,
              DEFAULT_MAX_DELIVERY_COUNT,
              DEFAULT_REPAIR_POLL_SECONDS,
              DEFAULT_REPAIR_POLL_BUCKET_FINALIZE_SECONDS,
-             DEFAULT_DELETE_BUCKETS_ON_FINALIZE);
+             DEFAULT_DELETE_BUCKETS_ON_FINALIZE,
+             Optional.empty());
     }
 
     @JsonCreator
@@ -62,7 +71,8 @@ public class QueueCreateOptions {
             @JsonProperty("maxDeliveryCount") Integer maxDeliveryCount,
             @JsonProperty("repairWorkerPollSeconds") Integer repairWorkerPollSeconds,
             @JsonProperty("repairWorkerBucketFinalizeTimeSeconds") Integer repairWorkerBucketFinalizeTimeSeconds,
-            @JsonProperty("deleteBucketsAfterFinalize") Boolean deleteBucketsAfterFinalize) {
+            @JsonProperty("deleteBucketsAfterFinalize") Boolean deleteBucketsAfterFinalize,
+            @JsonProperty("dlqName") Optional<QueueName> dlqName) {
 
         this.queueName = queueName;
 
@@ -74,5 +84,7 @@ public class QueueCreateOptions {
                 repairWorkerBucketFinalizeTimeSeconds == null ? DEFAULT_REPAIR_POLL_BUCKET_FINALIZE_SECONDS : repairWorkerBucketFinalizeTimeSeconds;
 
         this.deleteBucketsAfterFinalize = deleteBucketsAfterFinalize == null ? DEFAULT_DELETE_BUCKETS_ON_FINALIZE : deleteBucketsAfterFinalize;
+
+        this.dlqName = dlqName;
     }
 }

--- a/model/src/main/java/io/paradoxical/cassieq/model/mappers/Mappers.java
+++ b/model/src/main/java/io/paradoxical/cassieq/model/mappers/Mappers.java
@@ -1,0 +1,34 @@
+package io.paradoxical.cassieq.model.mappers;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.xebia.jacksonlombok.JacksonLombokAnnotationIntrospector;
+
+public class Mappers {
+    public static ObjectMapper getJson() {
+        return new ObjectMapper().configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                                 .configure(SerializationFeature.INDENT_OUTPUT, true)
+                                 .configure(SerializationFeature.WRITE_NULL_MAP_VALUES, true)
+                                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                                 .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
+                                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                                 .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                                 .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
+                                 .configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
+                                 .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+                                 .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
+                                 .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
+                                 .setAnnotationIntrospector(new JacksonLombokAnnotationIntrospector())
+                                 .registerModule(new JodaModule())
+                                 .registerModule(new GuavaModule())
+                                 .registerModule(new Jdk7Module())
+                                 .registerModule(new Jdk8Module());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,12 @@
         <java.version>1.8</java.version>
 
         <!-- Library Versions -->
-        <io.paradoxical.common.test>1.1-SNAPSHOT</io.paradoxical.common.test>
-        <io.paradoxical.common>1.2-SNAPSHOT</io.paradoxical.common>
-        <io.paradoxical.common.web>1.1-SNAPSHOT</io.paradoxical.common.web>
-        <io.paradoxical.cassandra-loader>1.2-SNAPSHOT</io.paradoxical.cassandra-loader>
+        <jackson.version>[2.6.0,2.6.999]</jackson.version>
+        <io.paradoxical.common.test>1.0</io.paradoxical.common.test>
+        <io.paradoxical.common>1.1</io.paradoxical.common>
+        <io.paradoxical.common.web>1.0</io.paradoxical.common.web>
+        <io.paradoxical.cassandra-loader>1.1</io.paradoxical.cassandra-loader>
+        <io.paradoxical.jackson-lombok.version>1.0</io.paradoxical.jackson-lombok.version>
         <guice.version>4.0</guice.version>
         <apache.collections4.version>4.0</apache.collections4.version>
         <godaddy.logging.version>1.0</godaddy.logging.version>
@@ -96,7 +98,7 @@
         <javaslang.version>2.0.0-RC2</javaslang.version>
         <hibernate.validator.version>5.2.2.Final</hibernate.validator.version>
         <assertj.version>3.2.0</assertj.version>
-        <lombok.version>1.16.2</lombok.version>
+        <lombok.version>1.16.6</lombok.version>
         <swagger.version>1.5.6</swagger.version>
         <apache.commons.io.version>2.4</apache.commons.io.version>
         <hazelcast.version>3.5.4</hazelcast.version>
@@ -127,6 +129,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.paradoxical</groupId>
+                <artifactId>jackson-lombok</artifactId>
+                <version>${io.paradoxical.jackson-lombok.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.github.rholder</groupId>
                 <artifactId>guava-retrying</artifactId>
@@ -418,6 +426,30 @@
                         <artifactId>jersey-container-servlet-core</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk7</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-guava</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-joda</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Addresses #57 

DLQ's can now be added on queue create by name. Not supported is DLQ's across accounts.  A DLQ is just another queue that will be the recipient of poison messages from another queue. DLQ's can have other DLQ's, so you can create interesting topology chains now

Deleting a queue that points to a DLQ does not affect the DLQ.  It's a separate queue, and you can publish into it all you want as well.  
