### PR TITLE
Adding HTTPS/SSL support

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -8,5 +8,7 @@ RUN curl -O -s http://central.maven.org/maven2/io/paradoxical/cassandra.loader/1
 # add the new jar/configs
 ADD data /data
 
+VOLUME ["/data/logs", "/data/conf", "/data/https"]
+
 # set the service to run
 ENTRYPOINT ["/data/bin/service"]

--- a/core/docker/data/bin/service
+++ b/core/docker/data/bin/service
@@ -92,5 +92,5 @@ case "$1" in
         run_app "gen-https" "$@";;
 
     *)
-        run_app "server $configFile";;
+        run_app "server" "$configFile";;
 esac

--- a/core/docker/data/bin/service
+++ b/core/docker/data/bin/service
@@ -12,6 +12,8 @@ function run_app(){
 
     command=$1
 
+    shift
+
     for jar in ${libs_dir}/*.jar; do
         classpath=$classpath:$jar
     done
@@ -32,7 +34,9 @@ function run_app(){
         echo "USING JAVA DEBUG $properties"
     fi
 
-    cmd="java $properties -cp $classpath $classname $command"
+    cmd="java $properties -cp $classpath $classname $command $@"
+
+    echo running ... ${cmd}
 
     exec ${cmd}
 }
@@ -82,6 +86,10 @@ case "$1" in
 
     "help")
         printHelp;;
+
+    "gen-https")
+        shift
+        run_app "gen-https" "$@";;
 
     *)
         run_app "server $configFile";;

--- a/core/docker/data/conf/configuration.yml
+++ b/core/docker/data/conf/configuration.yml
@@ -1,12 +1,29 @@
 server:
   adminMinThreads: 1
   adminMaxThreads: 64
+<#if env.HTTPS?has_content && env.HTTPS == "true">
+  applicationConnectors:
+    - type: https
+      keyStoreType: ${env.HTTPS_KEY_STORE_TYPE!'PKCS12'}
+      keyStorePath: ${env.HTTPS_KEY_STORE_PATH!'/data/https/serverKeys.p12'}
+      keyStorePassword: ${env.HTTPS_KEY_STORE_PASSWORD}
+      validateCerts: ${env.HTTPS_VALIDATE_CERTS!'true'}
+      port: 8080
+  adminConnectors:
+    - type: https
+      keyStoreType: ${env.HTTPS_KEY_STORE_TYPE!'PKCS12'}
+      keyStorePath: ${env.HTTPS_KEY_STORE_PATH!'/data/https/serverKeys.p12'}
+      keyStorePassword: ${env.HTTPS_KEY_STORE_PASSWORD}
+      validateCerts: ${env.HTTPS_VALIDATE_CERTS!'true'}
+      port: 8081
+<#else>
   applicationConnectors:
     - type: http
       port: 8080
   adminConnectors:
     - type: http
       port: 8081
+</#if>
 
 allocation:
   strategy: ${env.ALLOCATION_STRATEGY!'CLUSTER'}

--- a/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
+++ b/core/src/main/java/io/paradoxical/cassieq/ServiceApplication.java
@@ -22,6 +22,7 @@ import io.paradoxical.cassieq.admin.resources.api.v1.AccountResource;
 import io.paradoxical.cassieq.admin.resources.api.v1.PermissionsResource;
 import io.paradoxical.cassieq.bundles.GuiceBundleProvider;
 import io.paradoxical.cassieq.commands.ConfigDumpCommand;
+import io.paradoxical.cassieq.commands.GenerateHttpsCertsCommand;
 import io.paradoxical.cassieq.configurations.LogMapping;
 import io.paradoxical.cassieq.discoverable.ApiDiscoverableRoot;
 import io.paradoxical.cassieq.serialization.JacksonJsonMapper;
@@ -72,6 +73,7 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
     @Override
     public void initialize(Bootstrap<ServiceConfiguration> bootstrap) {
         bootstrap.addCommand(new ConfigDumpCommand());
+        bootstrap.addCommand(new GenerateHttpsCertsCommand());
 
         bootstrap.addBundle(new TemplateConfigBundle());
 

--- a/core/src/main/java/io/paradoxical/cassieq/commands/GenerateHttpsCertsCommand.java
+++ b/core/src/main/java/io/paradoxical/cassieq/commands/GenerateHttpsCertsCommand.java
@@ -1,0 +1,113 @@
+package io.paradoxical.cassieq.commands;
+
+import com.google.common.base.Joiner;
+import io.dropwizard.cli.Command;
+import io.dropwizard.setup.Bootstrap;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+import java.io.File;
+import java.io.IOException;
+
+public class GenerateHttpsCertsCommand extends Command {
+    public GenerateHttpsCertsCommand() {
+        super("gen-https", "Generates Self-Signed https certificates, useful for getting HTTPS setup easily. " +
+                           "Writes output to /data/https so make sure that volume is mounted");
+    }
+
+    @Override
+    public void configure(final Subparser subparser) {
+        subparser.addArgument("password")
+                 .dest("password")
+                 .type(String.class)
+                 .help("the PKCS12 certificate store password")
+                 .required(true);
+
+        subparser.addArgument("certName")
+                 .dest("certName")
+                 .type(String.class)
+                 .help("the generated certificates common name (CN)")
+                 .required(true);
+
+        subparser.addArgument("days")
+                 .dest("vaildDays")
+                 .type(Integer.class)
+                 .help("the number of days the certificate should be valid for (Default: 30)")
+                 .setDefault(30)
+                 .required(false);
+    }
+
+    @Override
+    public void run(final Bootstrap<?> bootstrap, final Namespace namespace) throws Exception {
+        final File outputDirectory = new File("/data/https");
+
+        System.out.println("Generating serverKeys.p12 into /data/https (make sure you have it mounted)");
+
+        buildCert(namespace, outputDirectory);
+
+        buildP12(namespace, outputDirectory);
+
+    }
+
+    private void buildCert(final Namespace namespace, final File outputDirectory) throws InterruptedException, IOException {
+        final String certName = String.format("/O=Paradoxical.io/OU=Generated-Certificates/CN=%s", namespace.getString("certName"));
+
+        final Integer vaildDays = namespace.getInt("vaildDays");
+
+        ProcessBuilder processBuilder =
+                new ProcessBuilder("openssl",
+                                   "req",
+                                   "-x509",
+                                   "-newkey", "2048",
+                                   "-keyout", "private_key.pem",
+                                   "-out", "cert.pem",
+                                   "-days", vaildDays.toString(),
+                                   "-nodes",
+                                   "-subj", certName)
+                        .inheritIO()
+                        .directory(outputDirectory);
+
+
+        final int result = processBuilder
+                .start()
+                .waitFor();
+
+        if (result != 0) {
+            System.out.println("oops something went wrong...");
+        }
+        else {
+            System.out.println("Successfully generated certificate...");
+            System.out.println();
+        }
+    }
+
+    private void buildP12(final Namespace namespace, final File outputDirectory) throws InterruptedException, IOException {
+        final String certName = namespace.getString("certName");
+
+        System.out.println("Adding generated certificate to PKCS12 file (/data/https/serverKeys.p12)");
+
+        ProcessBuilder processBuilder =
+                new ProcessBuilder("openssl",
+                                   "pkcs12",
+                                   "-export",
+                                   "-out", "serverKeys.p12",
+                                   "-password", "pass:" + namespace.getString("password"),
+                                   "-in", "cert.pem",
+                                   "-inkey", "private_key.pem",
+                                   "-name", certName)
+                        .inheritIO()
+                        .directory(outputDirectory);
+
+        final Process process = processBuilder.start();
+
+        final int result = process
+                .waitFor();
+
+        if (result != 0) {
+            System.out.println("oops something went wrong generating p12...");
+        }
+        else{
+            System.out.println("serverKeys.p12 successfully generated into /data/https");
+        }
+    }
+}


### PR DESCRIPTION
Exposing HTTP environment variables to configure https support
Adding a command to help setup a self signed certificate for use with
HTTPS (good for testing)

This resolves #74 

Will add wiki on how to use gen-https
