### PR TITLE
Fix signed url queue name parsing

### DIFF
--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedRequestAuthenticationFilter.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedRequestAuthenticationFilter.java
@@ -178,6 +178,7 @@ public class SignedRequestAuthenticationFilter<TPrincipal extends Principal> ext
 
         final java.util.Optional<DateTime> startTime = parseTimeParam(queryParameters, SignedUrlParameterNames.StartTime);
         final java.util.Optional<DateTime> endTime = parseTimeParam(queryParameters, SignedUrlParameterNames.EndTime);
+        final java.util.Optional<QueueName> authQueueName = parseQueueName(queryParameters);
 
         return SignedUrlParameters.builder()
                                   .accountName(accountName)
@@ -185,9 +186,21 @@ public class SignedRequestAuthenticationFilter<TPrincipal extends Principal> ext
                                   .querySignature(sig)
                                   .endDateTime(endTime)
                                   .startDateTime(startTime)
-                                  .queueName(queueName)
+                                  .queueName(authQueueName)
                                   .build();
 
+    }
+
+    private java.util.Optional<QueueName> parseQueueName(
+            final MultivaluedMap<String, String> queryParameters) {
+
+        final String queueName = queryParameters.getFirst(SignedUrlParameterNames.Queue.getParameterName());
+
+        if (Strings.isNullOrEmpty(queueName)) {
+            return java.util.Optional.empty();
+        }
+
+        return java.util.Optional.of(QueueName.valueOf(queueName));
     }
 
     private java.util.Optional<DateTime> parseTimeParam(

--- a/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedUrlParameters.java
+++ b/core/src/main/java/io/paradoxical/cassieq/discoverable/auth/SignedUrlParameters.java
@@ -65,7 +65,7 @@ public class SignedUrlParameters extends SignedParametersBase implements Request
 
     private boolean queueAllowed(final VerificationContext context) {
         return !queueName.isPresent() || // no queue restriction
-    context.getQueueName().equals(queueName);
+               context.getQueueName().equals(queueName);
     }
 
     private boolean requestInAllowedTimeFrame(final VerificationContext context) {


### PR DESCRIPTION
We weren’t parsing queue names out of the query string parameter.
