### PR TITLE
Exposing CORS via config

### DIFF
--- a/core/src/main/java/io/paradoxical/cassieq/ServiceConfiguration.java
+++ b/core/src/main/java/io/paradoxical/cassieq/ServiceConfiguration.java
@@ -19,6 +19,11 @@ import javax.validation.constraints.NotNull;
 public class ServiceConfiguration extends Configuration {
     @Valid
     @NotNull
+    @JsonProperty("web")
+    private WebConfiguration web = new WebConfiguration();
+
+    @Valid
+    @NotNull
     @JsonProperty("cassandra")
     private CassandraConfiguration cassandra = new CassandraConfiguration();
 

--- a/core/src/main/java/io/paradoxical/cassieq/WebConfiguration.java
+++ b/core/src/main/java/io/paradoxical/cassieq/WebConfiguration.java
@@ -1,0 +1,18 @@
+package io.paradoxical.cassieq;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.paradoxical.cassieq.environment.SystemProps;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class WebConfiguration {
+    @JsonProperty("allowedOrigins")
+    private String allowedOriginsRaw = SystemProps.instance().CORS_ALLOWED_ORIGINS();
+
+    @JsonIgnore
+    public List<String> getAllowedOrigins() {
+        return Arrays.asList(allowedOriginsRaw.split(","));
+    }
+}

--- a/core/src/main/java/io/paradoxical/cassieq/configurations/LogConfig.java
+++ b/core/src/main/java/io/paradoxical/cassieq/configurations/LogConfig.java
@@ -1,8 +1,9 @@
 package io.paradoxical.cassieq.configurations;
 
+import io.paradoxical.cassieq.environment.SystemProps;
 import lombok.Data;
 
 @Data
 public class LogConfig {
-    private Boolean logRawJerseyRequests = false;
+    private Boolean logRawJerseyRequests = SystemProps.instance().LOG_RAW_REQUESTS();
 }

--- a/core/src/main/java/io/paradoxical/cassieq/environment/SystemProps.java
+++ b/core/src/main/java/io/paradoxical/cassieq/environment/SystemProps.java
@@ -71,6 +71,12 @@ public interface SystemProps {
     @Env(defaultValue = "", help = "The graphite prefix")
     String GRAPHITE_PREFIX();
 
+    @Env(defaultValue = "*", help = "Allowed CORS origins (comma separated)")
+    String CORS_ALLOWED_ORIGINS();
+
+    @Env(defaultValue = "false", help = "Log raw requests to console")
+    Boolean LOG_RAW_REQUESTS();
+
     static List<SystemPropDiscovery> discover() {
         return Arrays.asList(SystemProps.class.getMethods())
                      .stream()
@@ -135,4 +141,6 @@ public interface SystemProps {
 
         throw new RuntimeException("Could not convert string to type: " + method.getName());
     }
+
+
 }


### PR DESCRIPTION
Addresses partially #102. Doesn't add cors dynamically by queue but at least someone can quickly enable cors with origins via config to get going.  Open to suggestions on how to dynamically do cors by queue, it seemed complicated. since we have to make sure that we dynamically add and remove filters by queue config then.  
