### PR TITLE
Fixing setup db null pointers

### DIFF
--- a/core/src/main/java/io/paradoxical/cassieq/commands/SetupDbCommand.java
+++ b/core/src/main/java/io/paradoxical/cassieq/commands/SetupDbCommand.java
@@ -56,16 +56,10 @@ public class SetupDbCommand extends Command {
                  .type(Integer.class)
                  .help("The port to connect to cassandra on");
 
-        subparser.addArgument("-v", "--databaseVersion")
-                 .dest("databaseVersion")
-                 .type(Integer.class)
-                 .setDefault(0)
-                 .help("The database version");
-
         subparser.addArgument("--recreate")
                  .dest("recreateKeyspace")
                  .action(Arguments.storeTrue())
-                 .help("weather or not to recreate the keyspace");
+                 .help("Whether or not to recreate the keyspace");
     }
 
     @Override
@@ -93,7 +87,6 @@ public class SetupDbCommand extends Command {
                        .password(password != null ? password : "")
                        .createKeyspace(namespace.getBoolean("shouldCreateKeyspace"))
                        .keyspace(namespace.getString("keyspace"))
-                       .dbVersion(namespace.getInt("databaseVersion"))
                        .filePath("/data/db")
                        .recreateDatabase(namespace.getBoolean("recreateKeyspace"));
 

--- a/core/src/main/java/io/paradoxical/cassieq/commands/SetupDbCommand.java
+++ b/core/src/main/java/io/paradoxical/cassieq/commands/SetupDbCommand.java
@@ -31,12 +31,10 @@ public class SetupDbCommand extends Command {
 
         subparser.addArgument("-u", "--userName")
                  .dest("userName")
-                 .setDefault("guest")
                  .help("Cassandra DB user name");
 
         subparser.addArgument("-p", "--password")
                  .dest("password")
-                 .setDefault("guest")
                  .help("Cassandra DB password");
 
         subparser.addArgument("--dontCreateKeyspace")

--- a/core/src/main/java/io/paradoxical/cassieq/commands/SetupDbCommand.java
+++ b/core/src/main/java/io/paradoxical/cassieq/commands/SetupDbCommand.java
@@ -1,17 +1,21 @@
 package io.paradoxical.cassieq.commands;
 
-import io.dropwizard.cli.ConfiguredCommand;
+import com.godaddy.logging.Logger;
+import io.dropwizard.cli.Command;
 import io.dropwizard.setup.Bootstrap;
 import io.paradoxical.cassandra.loader.DbRunnerConfig;
 import io.paradoxical.cassandra.loader.DbScriptsRunner;
-import io.paradoxical.cassieq.ServiceConfiguration;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
 import java.util.Scanner;
 
-public class SetupDbCommand extends ConfiguredCommand<ServiceConfiguration> {
+import static com.godaddy.logging.LoggerFactory.getLogger;
+
+public class SetupDbCommand extends Command {
+
+    private static final Logger logger = getLogger(SetupDbCommand.class);
 
     public SetupDbCommand() {
         super("setup-db", "Initializes the cassandra database");
@@ -19,22 +23,20 @@ public class SetupDbCommand extends ConfiguredCommand<ServiceConfiguration> {
 
     @Override
     public void configure(final Subparser subparser) {
-        subparser.addArgument("--config")
-                 .dest("file")
-                 .nargs("?")
-                 .setDefault("/data/conf/configuration.yml")
-                 .help("application configuration file");
 
         subparser.addArgument("-i", "--ip")
                  .dest("ip")
+                 .required(true)
                  .help("Cassandra cluster IP");
 
         subparser.addArgument("-u", "--userName")
                  .dest("userName")
+                 .setDefault("guest")
                  .help("Cassandra DB user name");
 
         subparser.addArgument("-p", "--password")
                  .dest("password")
+                 .setDefault("guest")
                  .help("Cassandra DB password");
 
         subparser.addArgument("--dontCreateKeyspace")
@@ -45,6 +47,7 @@ public class SetupDbCommand extends ConfiguredCommand<ServiceConfiguration> {
 
         subparser.addArgument("-k", "--keyspace")
                  .dest("keyspace")
+                 .required(true)
                  .help("the keyspace to create");
 
         subparser.addArgument("--port")
@@ -63,14 +66,10 @@ public class SetupDbCommand extends ConfiguredCommand<ServiceConfiguration> {
                  .dest("recreateKeyspace")
                  .action(Arguments.storeTrue())
                  .help("weather or not to recreate the keyspace");
-
     }
 
     @Override
-    protected void run(
-            final Bootstrap<ServiceConfiguration> bootstrap,
-            final Namespace namespace,
-            final ServiceConfiguration configuration) throws Exception {
+    public void run(final Bootstrap<?> bootstrap, final Namespace namespace) throws Exception {
         DbRunnerConfig dbRunnerConfig = getDbRunnerConfig(namespace);
 
         if (dbRunnerConfig.getRecreateDatabase()) {


### PR DESCRIPTION
Setup db run with no arguments gave a null pointer, since we never specified any required args. If you ran with zero args it tried to use the config, but the config might not be set up properly without environment variables.  I removed the config option and set fields to be required, so this way you get a nice discoverable prompt on what you need to pass in.

I also removed db version settings, since the message was incorrect (it isn't where you start from, it s where you upgrade to).  So if we had included a 01 script, the setupdb script would never have run it and people's schemas would be on old versions.  Really, we want them to just always be at the latest for that CQ version. If they want to downgrade they can blow out their keyspace and run an older version's setup db. 
